### PR TITLE
Print less process information by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ ptcpdump -r demo.pcapng
 Default:
 
 ```
-09:32:09.718892 vethee2a302f In IP 10.244.0.2.33426 > 139.178.84.217.80: Flags [S], seq 4113492822, win 64240, length 0, Process [/usr/bin/wget.3553008], Container [test], Pod [test.default]
-09:32:09.718941 eth0 Out IP 172.19.0.2.33426 > 139.178.84.217.80: Flags [S], seq 4113492822, win 64240, length 0, Process [/usr/bin/wget.3553008], Container [test], Pod [test.default]
+09:32:09.718892 vethee2a302f wget.3553008 In IP 10.244.0.2.33426 > 139.178.84.217.80: Flags [S], seq 4113492822, win 64240, length 0, Container [test], Pod [test.default]
+09:32:09.718941 eth0 wget.3553008 Out IP 172.19.0.2.33426 > 139.178.84.217.80: Flags [S], seq 4113492822, win 64240, length 0, Container [test], Pod [test.default]
 ```
 
 With `-v`:

--- a/internal/types/process.go
+++ b/internal/types/process.go
@@ -19,16 +19,21 @@ type Process struct {
 }
 
 func (p Process) MatchComm(name string) bool {
-	filename := filepath.Base(p.Cmd)
+	filename := p.Comm()
 	if len(filename) > 15 {
 		filename = filename[:15]
 	}
 	return name == filename
 }
+
 func (p Process) FormatArgs() string {
 	s := strings.Join(p.Args, " ")
 	if p.ArgsTruncated {
 		s += "..."
 	}
 	return s
+}
+
+func (p Process) Comm() string {
+	return filepath.Base(p.Cmd)
 }

--- a/internal/writer/stdout.go
+++ b/internal/writer/stdout.go
@@ -64,7 +64,7 @@ func (w *StdoutWriter) Write(e *event.Packet) error {
 			p.Pod.Name, p.Pod.Namespace, p.Pod.Uid, p.Pod.FormatLabels(), p.Pod.FormatAnnotations())
 		break
 	default:
-		pidInfo = fmt.Sprintf("Process [%s.%d]", p.Cmd, e.Pid)
+		pidInfo = fmt.Sprintf("%s.%d", p.Comm(), e.Pid)
 		containerInfo = fmt.Sprintf("Container [%s]", p.Container.TidyName())
 		PodInfo = fmt.Sprintf("Pod [%s.%s]", p.Pod.Name, p.Pod.Namespace)
 	}
@@ -86,6 +86,9 @@ func (w *StdoutWriter) Write(e *event.Packet) error {
 	if ifName != "" {
 		builder.WriteString(fmt.Sprintf("%s ", ifName))
 	}
+	if p.Pid > 0 && w.FormatStyle <= pktdump.FormatStyleNormal {
+		builder.WriteString(fmt.Sprintf("%s ", pidInfo))
+	}
 	if packetType != "" {
 		builder.WriteString(fmt.Sprintf("%s ", packetType))
 	}
@@ -105,9 +108,6 @@ func (w *StdoutWriter) Write(e *event.Packet) error {
 		break
 	default:
 		builder.WriteString(formated)
-		if p.Pid > 0 {
-			builder.WriteString(fmt.Sprintf(", %s", pidInfo))
-		}
 		if p.Container.Id != "" {
 			builder.WriteString(fmt.Sprintf(", %s", containerInfo))
 		}

--- a/testdata/run_e2e.sh
+++ b/testdata/run_e2e.sh
@@ -3,7 +3,9 @@
 set -ex
 
 function main() {
-  rm -rf /tmp/ptcpdump_*
+  rm -rf /tmp/ptcpdump_* | true
+  kubectl delet pod test-ptcpdump | true
+
   bash testdata/test_default.sh ./ptcpdump
   bash testdata/test_base.sh ./ptcpdump
 

--- a/testdata/test_arp.sh
+++ b/testdata/test_arp.sh
@@ -11,7 +11,7 @@ RNAME="${FILE_PREFIX}_arp.read.txt"
 
 function test_ptcpdump() {
   which arping || (apt update || true && apt install -y iputils-arping)
-  timeout 30s ${CMD} -c 2 -i any --print -w "${FNAME}" \
+  timeout 30s ${CMD} -c 2 -i any -v --print -w "${FNAME}" \
 	  'arp host 1.1.1.1' | tee "${LNAME}" &
   sleep 10
   arping -w 10 -c 2 1.1.1.1 &>/dev/null || true
@@ -31,7 +31,7 @@ function test_tcpdump_read() {
 function test_ptcpdump_read() {
     EXPECT_NAME="${LNAME}.read.expect"
     sed 's/ [a-zA-Z0-9_-]\+ \(In\|Out\) / /g' "${LNAME}" > "${EXPECT_NAME}"
-    timeout 30s ${CMD} -r "${FNAME}" > "${RNAME}"
+    timeout 30s ${CMD} -v -r "${FNAME}" > "${RNAME}"
     diff "${EXPECT_NAME}" "${RNAME}"
 }
 

--- a/testdata/test_base.sh
+++ b/testdata/test_base.sh
@@ -10,7 +10,7 @@ RNAME="${FILE_PREFIX}_base.read.txt"
 
 
 function test_ptcpdump() {
-  timeout 30s ${CMD} -c 1 -i any --print -w "${FNAME}" --exec-events-worker-number=50 \
+  timeout 30s ${CMD} -c 1 -v -i any --print -w "${FNAME}" --exec-events-worker-number=50 \
     'dst host 1.1.1.1 and tcp[tcpflags] = tcp-syn' | tee "${LNAME}" &
   sleep 10
   curl -m 10 1.1.1.1 &>/dev/null || true
@@ -30,7 +30,7 @@ function test_tcpdump_read() {
 function test_ptcpdump_read() {
     EXPECT_NAME="${LNAME}.read.expect"
     sed 's/ [a-zA-Z0-9_-]\+ \(In\|Out\) / /g' "${LNAME}" > "${EXPECT_NAME}"
-    timeout 30s ${CMD} -r "${FNAME}" > "${RNAME}"
+    timeout 30s ${CMD} -v -r "${FNAME}" > "${RNAME}"
     diff "${EXPECT_NAME}" "${RNAME}"
 }
 

--- a/testdata/test_containerd.sh
+++ b/testdata/test_containerd.sh
@@ -14,7 +14,7 @@ function test_ptcpdump() {
   nerdctl pull alpine:3.18
 
   timeout 120s ${CMD} -i any --print -w "${FNAME}" --oneline -v --exec-events-worker-number=50 \
-    'host 1.1.1.1' -w "${FNAME}" | tee "${LNAME}" &
+    'host 1.1.1.1 and port 80' -w "${FNAME}" | tee "${LNAME}" &
   sleep 10
 
   cid1=$(nerdctl run -d busybox:1 sh -c 'sleep 10; wget -T 10 1.1.1.1')

--- a/testdata/test_default.sh
+++ b/testdata/test_default.sh
@@ -10,7 +10,7 @@ RNAME="${FILE_PREFIX}_default.read.txt"
 
 
 function test_ptcpdump() {
-  timeout 30s ${CMD} -c 2 -i lo --print -w "${FNAME}" \
+  timeout 30s ${CMD} -c 2 -i lo -v --print -w "${FNAME}" \
       'icmp and host 127.0.0.1' | tee "${LNAME}" &
   sleep 10
   ping -c 1 127.0.0.1 &>/dev/null || true
@@ -30,7 +30,7 @@ function test_tcpdump_read() {
 function test_ptcpdump_read() {
     EXPECT_NAME="${LNAME}.read.expect"
     sed 's/ [a-zA-Z0-9_-]\+ \(In\|Out\) / /g' "${LNAME}" > "${EXPECT_NAME}"
-    timeout 30s ${CMD} -r "${FNAME}" > "${RNAME}"
+    timeout 30s ${CMD} -v -r "${FNAME}" > "${RNAME}"
     diff "${EXPECT_NAME}" "${RNAME}"
 }
 

--- a/testdata/test_exist_connection.sh
+++ b/testdata/test_exist_connection.sh
@@ -22,13 +22,13 @@ function test_ptcpdump() {
 
   cat "${LNAME}"
   cat "${LNAME}" | grep -F 'cmd /usr/sbin/sshd'
-  cat "${LNAME}" | grep -F '.22: Flags [.]'
+  cat "${LNAME}" | grep '.22 .*Flags \[.\+\]'
 }
 
 function test_tcpdump_read() {
   which tcpdump || (apt update || true && apt install -y tcpdump)
   tcpdump -nr "${FNAME}"
-  tcpdump -nr "${FNAME}" | grep -F '.22: Flags [.]'
+  tcpdump -nr "${FNAME}" | grep '.22 .*Flags \[.\+\]'
 
 }
 

--- a/testdata/test_pid_filter.sh
+++ b/testdata/test_pid_filter.sh
@@ -10,7 +10,7 @@ RNAME="${FILE_PREFIX}_filter_by_pid.read.txt"
 
 
 function test_ptcpdump() {
-  timeout 30s ${CMD} -c 6 --pid $$ -f -i any --print -w "${FNAME}" --exec-events-worker-number=50 | tee "${LNAME}" &
+  timeout 30s ${CMD} -c 6 --pid $$ -f -v -i any --print -w "${FNAME}" --exec-events-worker-number=50 | tee "${LNAME}" &
   sleep 10
   curl -m 10 1.1.1.1 &>/dev/null || true
   wait
@@ -33,7 +33,7 @@ function test_tcpdump_read() {
 function test_ptcpdump_read() {
     EXPECT_NAME="${LNAME}.read.expect"
     sed 's/ [a-zA-Z0-9_-]\+ \(In\|Out\) / /g' "${LNAME}" > "${EXPECT_NAME}"
-    timeout 30s ${CMD} -r "${FNAME}" > "${RNAME}"
+    timeout 30s ${CMD} -v -r "${FNAME}" > "${RNAME}"
     diff "${EXPECT_NAME}" "${RNAME}"
 }
 

--- a/testdata/test_pname_filter.sh
+++ b/testdata/test_pname_filter.sh
@@ -10,7 +10,7 @@ RNAME="${FILE_PREFIX}_filter_by_pname.read.txt"
 
 
 function test_ptcpdump() {
-  timeout 30s ${CMD} -c 6 --pname curl -f -i any --print -w "${FNAME}" --exec-events-worker-number=50 | tee "${LNAME}" &
+  timeout 30s ${CMD} -c 6 -v --pname curl -f -i any --print -w "${FNAME}" --exec-events-worker-number=50 | tee "${LNAME}" &
   sleep 10
   curl -m 10 1.1.1.1 &>/dev/null || true
   wait
@@ -33,7 +33,7 @@ function test_tcpdump_read() {
 function test_ptcpdump_read() {
     EXPECT_NAME="${LNAME}.read.expect"
     sed 's/ [a-zA-Z0-9_-]\+ \(In\|Out\) / /g' "${LNAME}" > "${EXPECT_NAME}"
-    timeout 30s ${CMD} -r "${FNAME}" > "${RNAME}"
+    timeout 30s ${CMD} -v -r "${FNAME}" > "${RNAME}"
     diff "${EXPECT_NAME}" "${RNAME}"
 }
 

--- a/testdata/test_sub_curl_domain_program.sh
+++ b/testdata/test_sub_curl_domain_program.sh
@@ -10,7 +10,7 @@ RNAME="${FILE_PREFIX}_sub_program_curl.read.txt"
 
 
 function test_ptcpdump() {
-  timeout 30s ${CMD} -i any --print -w "${FNAME}" --exec-events-worker-number=50 \
+  timeout 30s ${CMD} -i any -v --print -w "${FNAME}" --exec-events-worker-number=50 \
 	  -- curl -m 10 ubuntu.com | tee "${LNAME}"
 
   cat "${LNAME}"
@@ -27,7 +27,7 @@ function test_tcpdump_read() {
 function test_ptcpdump_read() {
     EXPECT_NAME="${LNAME}.read.expect"
     sed 's/ [a-zA-Z0-9_-]\+ \(In\|Out\) / /g' "${LNAME}" > "${EXPECT_NAME}"
-    timeout 30s ${CMD} -r "${FNAME}" > "${RNAME}"
+    timeout 30s ${CMD} -v -r "${FNAME}" > "${RNAME}"
     diff "${EXPECT_NAME}" "${RNAME}"
 }
 

--- a/testdata/test_sub_program.sh
+++ b/testdata/test_sub_program.sh
@@ -10,7 +10,7 @@ RNAME="${FILE_PREFIX}_sub_program.read.txt"
 
 
 function test_ptcpdump() {
-  timeout 30s ${CMD} -i any --print -w "${FNAME}" --exec-events-worker-number=50 \
+  timeout 30s ${CMD} -i any -v --print -w "${FNAME}" --exec-events-worker-number=50 \
 	  -- curl -m 10 1.1.1.1 | tee "${LNAME}"
 
   cat "${LNAME}"
@@ -31,7 +31,7 @@ function test_tcpdump_read() {
 function test_ptcpdump_read() {
     EXPECT_NAME="${LNAME}.read.expect"
     sed 's/ [a-zA-Z0-9_-]\+ \(In\|Out\) / /g' "${LNAME}" > "${EXPECT_NAME}"
-    timeout 30s ${CMD} -r "${FNAME}" > "${RNAME}"
+    timeout 30s ${CMD} -v -r "${FNAME}" > "${RNAME}"
     diff "${EXPECT_NAME}" "${RNAME}"
 }
 


### PR DESCRIPTION
Before:

```
13:12:34.155862 enp5s0 Out IP 192.168.2.50.22 > 192.168.2.100.61061: Flags [P.], seq 26636148:26636216, ack 1379806263, win 524, length 68, Process [/usr/sbin/sshd.9655]
```

After:

```
13:12:34.155862 enp5s0 sshd.9655 Out IP 192.168.2.50.22 > 192.168.2.100.61061: Flags [P.], seq 26636148:26636216, ack 1379806263, win 524, length 68
```