### PR TITLE
all: reduce dependencies

### DIFF
--- a/bpf/event.go
+++ b/bpf/event.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"unsafe"
 
 	"github.com/cilium/ebpf/perf"
-	"golang.org/x/xerrors"
 
 	"github.com/mozillazg/ptcpdump/internal/log"
 )
@@ -32,7 +32,7 @@ func (b *BPF) PullPacketEvents(ctx context.Context, chanSize int, maxPacketSize 
 
 	reader, err := perf.NewReader(b.objs.PacketEvents, perCPUBuffer)
 	if err != nil {
-		return nil, xerrors.Errorf(": %w", err)
+		return nil, fmt.Errorf(": %w", err)
 	}
 	ch := make(chan BpfPacketEventWithPayloadT, chanSize)
 	go func() {
@@ -79,7 +79,7 @@ func (b *BPF) handlePacketEvents(ctx context.Context, reader *perf.Reader, ch ch
 func parsePacketEvent(rawSample []byte) (*BpfPacketEventWithPayloadT, error) {
 	event := BpfPacketEventWithPayloadT{}
 	if err := binary.Read(bytes.NewBuffer(rawSample), binary.LittleEndian, &event.Meta); err != nil {
-		return nil, xerrors.Errorf("parse meta: %w", err)
+		return nil, fmt.Errorf("parse meta: %w", err)
 	}
 	event.Payload = make([]byte, int(event.Meta.PacketSize))
 	copy(event.Payload[:], rawSample[unsafe.Sizeof(BpfPacketEventT{}):])
@@ -98,7 +98,7 @@ func (b *BPF) PullExecEvents(ctx context.Context, chanSize int) (<-chan BpfExecE
 
 	reader, err := perf.NewReader(b.objs.ExecEvents, perCPUBuffer)
 	if err != nil {
-		return nil, xerrors.Errorf(": %w", err)
+		return nil, fmt.Errorf(": %w", err)
 	}
 	ch := make(chan BpfExecEventT, chanSize)
 	go func() {
@@ -145,7 +145,7 @@ func (b *BPF) handleExecEvents(ctx context.Context, reader *perf.Reader, ch chan
 func parseExecEvent(rawSample []byte) (*BpfExecEventT, error) {
 	event := BpfExecEventT{}
 	if err := binary.Read(bytes.NewBuffer(rawSample), binary.LittleEndian, &event); err != nil {
-		return nil, xerrors.Errorf("parse event: %w", err)
+		return nil, fmt.Errorf("parse event: %w", err)
 	}
 	return &event, nil
 }
@@ -162,7 +162,7 @@ func (b *BPF) PullExitEvents(ctx context.Context, chanSize int) (<-chan BpfExitE
 
 	reader, err := perf.NewReader(b.objs.ExitEvents, perCPUBuffer)
 	if err != nil {
-		return nil, xerrors.Errorf(": %w", err)
+		return nil, fmt.Errorf(": %w", err)
 	}
 	ch := make(chan BpfExitEventT, chanSize)
 	go func() {
@@ -209,7 +209,7 @@ func (b *BPF) handleExitEvents(ctx context.Context, reader *perf.Reader, ch chan
 func parseExitEvent(rawSample []byte) (*BpfExitEventT, error) {
 	event := BpfExitEventT{}
 	if err := binary.Read(bytes.NewBuffer(rawSample), binary.LittleEndian, &event); err != nil {
-		return nil, xerrors.Errorf("parse event: %w", err)
+		return nil, fmt.Errorf("parse event: %w", err)
 	}
 	return &event, nil
 }

--- a/cmd/ebpf.go
+++ b/cmd/ebpf.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/binary"
+	"fmt"
 	"net/netip"
 
 	"github.com/cilium/ebpf/rlimit"
@@ -10,7 +11,6 @@ import (
 	"github.com/mozillazg/ptcpdump/internal/log"
 	"github.com/mozillazg/ptcpdump/internal/metadata"
 	"github.com/mozillazg/ptcpdump/internal/utils"
-	"golang.org/x/xerrors"
 )
 
 func attachHooks(currentConns []metadata.Connection, opts Options) (*bpf.BPF, error) {
@@ -77,7 +77,7 @@ func updateFlowPidMapValues(bf *bpf.BPF, conns []metadata.Connection) error {
 		data[&k] = v
 	}
 	if err := bf.UpdateFlowPidMapValues(data); err != nil {
-		return xerrors.Errorf(": %w", err)
+		return fmt.Errorf(": %w", err)
 	}
 	return nil
 }

--- a/cmd/writer.go
+++ b/cmd/writer.go
@@ -15,7 +15,6 @@ import (
 	"github.com/mozillazg/ptcpdump/internal/metadata"
 	"github.com/mozillazg/ptcpdump/internal/writer"
 	"github.com/x-way/pktdump"
-	"golang.org/x/xerrors"
 )
 
 func getWriters(opts Options, pcache *metadata.ProcessCache) ([]writer.PacketWriter, func() error, error) {
@@ -29,7 +28,7 @@ func getWriters(opts Options, pcache *metadata.ProcessCache) ([]writer.PacketWri
 		case opts.WritePath() == "-":
 			w, err := newPcapNgWriter(os.Stdout, pcache)
 			if err != nil {
-				return nil, nil, xerrors.Errorf(": %w", err)
+				return nil, nil, fmt.Errorf(": %w", err)
 			}
 			w.WithNoBuffer()
 			writers = append(writers, w)
@@ -37,22 +36,22 @@ func getWriters(opts Options, pcache *metadata.ProcessCache) ([]writer.PacketWri
 		case ext == extPcap:
 			pcapFile, err = os.Create(opts.WritePath())
 			if err != nil {
-				return nil, nil, xerrors.Errorf(": %w", err)
+				return nil, nil, fmt.Errorf(": %w", err)
 			}
 			w, err := newPcapWriter(pcapFile)
 			if err != nil {
-				return nil, pcapFile.Close, xerrors.Errorf(": %w", err)
+				return nil, pcapFile.Close, fmt.Errorf(": %w", err)
 			}
 			writers = append(writers, w)
 			break
 		default:
 			pcapFile, err = os.Create(opts.WritePath())
 			if err != nil {
-				return nil, nil, xerrors.Errorf(": %w", err)
+				return nil, nil, fmt.Errorf(": %w", err)
 			}
 			w, err := newPcapNgWriter(pcapFile, pcache)
 			if err != nil {
-				return nil, pcapFile.Close, xerrors.Errorf(": %w", err)
+				return nil, pcapFile.Close, fmt.Errorf(": %w", err)
 			}
 			writers = append(writers, w)
 		}
@@ -82,7 +81,7 @@ func getWriters(opts Options, pcache *metadata.ProcessCache) ([]writer.PacketWri
 func newPcapNgWriter(w io.Writer, pcache *metadata.ProcessCache) (*writer.PcapNGWriter, error) {
 	devices, err := dev.GetDevices(nil)
 	if err != nil {
-		return nil, xerrors.Errorf(": %w", err)
+		return nil, fmt.Errorf(": %w", err)
 	}
 	// to avoid "Interface id 9 not present in section (have only 7 interfaces)"
 	var maxIndex int
@@ -126,17 +125,17 @@ func newPcapNgWriter(w io.Writer, pcache *metadata.ProcessCache) (*writer.PcapNG
 		},
 	})
 	if err != nil {
-		return nil, xerrors.Errorf(": %w", err)
+		return nil, fmt.Errorf(": %w", err)
 	}
 	for _, ifc := range interfaces[1:] {
 		_, err := pcapNgWriter.AddInterface(ifc)
 		if err != nil {
-			return nil, xerrors.Errorf(": %w", err)
+			return nil, fmt.Errorf(": %w", err)
 		}
 	}
 
 	if err := pcapNgWriter.Flush(); err != nil {
-		return nil, xerrors.Errorf("writing pcapNg header: %w", err)
+		return nil, fmt.Errorf("writing pcapNg header: %w", err)
 	}
 
 	return writer.NewPcapNGWriter(pcapNgWriter, pcache), nil
@@ -146,7 +145,7 @@ func newPcapWriter(w io.Writer) (*writer.PcapWriter, error) {
 	pcapWriter := pcapgo.NewWriterNanos(w)
 
 	if err := pcapWriter.WriteFileHeader(65536, layers.LinkTypeEthernet); err != nil {
-		return nil, xerrors.Errorf("writing pcap header: %w", err)
+		return nil, fmt.Errorf("writing pcap header: %w", err)
 	}
 
 	return writer.NewPcapWriter(pcapWriter), nil

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/x-way/pktdump v0.0.5
 	golang.org/x/sys v0.20.0
-	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
 	k8s.io/cri-client v0.31.0-alpha.0.0.20240530211015-c9749ee02fc0
 	k8s.io/klog/v2 v2.120.1
 )

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/phuslu/log v1.0.106
 	github.com/shirou/gopsutil/v3 v3.24.4
 	github.com/spf13/cobra v1.8.0
-	github.com/vishvananda/netlink v1.2.1-beta.2
 	github.com/x-way/pktdump v0.0.5
 	golang.org/x/sys v0.20.0
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
@@ -92,7 +91,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
-	github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.51.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -254,7 +254,6 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/vishvananda/netlink v1.2.1-beta.2 h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0mPkuhwHfStVs=
 github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
-github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 h1:gga7acRE695APm9hlsSMoOoE65U4/TcqNj90mc69Rlg=
 github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -338,8 +337,6 @@ golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201118182958-a01c418693c7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -385,8 +385,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
-golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/internal/dev/dev.go
+++ b/internal/dev/dev.go
@@ -1,10 +1,9 @@
 package dev
 
 import (
+	"fmt"
 	"net"
 	"sync"
-
-	"golang.org/x/xerrors"
 )
 
 var allLinks []net.Interface
@@ -30,7 +29,7 @@ func GetDevices(names []string) (map[int]Device, error) {
 
 	allLinks, err := getAllLinks()
 	if err != nil {
-		return nil, xerrors.Errorf(": %w", err)
+		return nil, fmt.Errorf(": %w", err)
 	}
 	if len(names) == 0 || names[0] == "any" {
 		links = append(links, allLinks...)

--- a/internal/metadata/container/containerd/containerd.go
+++ b/internal/metadata/container/containerd/containerd.go
@@ -3,6 +3,7 @@ package containerd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"sync"
@@ -16,7 +17,6 @@ import (
 	"github.com/mozillazg/ptcpdump/internal/log"
 	"github.com/mozillazg/ptcpdump/internal/types"
 	"github.com/mozillazg/ptcpdump/internal/utils"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -255,7 +255,7 @@ func (d *MetaData) init(ctx context.Context) error {
 	c := d.client
 	containers, err := c.Containers(ctx)
 	if err != nil {
-		return xerrors.Errorf("list containers: %w", err)
+		return fmt.Errorf("list containers: %w", err)
 	}
 	for _, cr := range containers {
 		d.saveContainer(ctx, cr)

--- a/internal/metadata/container/docker/docker.go
+++ b/internal/metadata/container/docker/docker.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"sync"
@@ -16,7 +17,6 @@ import (
 	"github.com/mozillazg/ptcpdump/internal/log"
 	"github.com/mozillazg/ptcpdump/internal/types"
 	"github.com/mozillazg/ptcpdump/internal/utils"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -211,7 +211,7 @@ func (d *MetaData) init(ctx context.Context) error {
 		Filters: filters.NewArgs(filters.Arg("status", "running")),
 	})
 	if err != nil {
-		return xerrors.Errorf("list containers: %w", err)
+		return fmt.Errorf("list containers: %w", err)
 	}
 	for _, cr := range containers {
 		d.handleContainerEvent(ctx, cr.ID)
@@ -296,7 +296,7 @@ func (d *MetaData) inspectContainer(ctx context.Context, containerId string) (*t
 
 	data, err := c.ContainerInspect(ctx, containerId)
 	if err != nil {
-		return nil, xerrors.Errorf("inspect container %s: %w", containerId, err)
+		return nil, fmt.Errorf("inspect container %s: %w", containerId, err)
 	}
 
 	cr := &types.Container{

--- a/internal/metadata/net.go
+++ b/internal/metadata/net.go
@@ -2,12 +2,12 @@ package metadata
 
 import (
 	"context"
+	"fmt"
 	"net/netip"
 
 	"github.com/mozillazg/ptcpdump/internal/utils"
 
 	"github.com/shirou/gopsutil/v3/net"
-	"golang.org/x/xerrors"
 )
 
 type Connection struct {
@@ -24,14 +24,14 @@ func GetCurrentConnects(ctx context.Context, pids []int, all bool) ([]Connection
 	if all {
 		sts, err := net.ConnectionsWithoutUidsWithContext(ctx, "all")
 		if err != nil {
-			return nil, xerrors.Errorf(": %w", err)
+			return nil, fmt.Errorf(": %w", err)
 		}
 		stats = append(stats, sts...)
 	} else {
 		for _, pid := range pids {
 			sts, err := net.ConnectionsPidWithoutUidsWithContext(ctx, "all", int32(pid))
 			if err != nil {
-				return nil, xerrors.Errorf(": %w", err)
+				return nil, fmt.Errorf(": %w", err)
 			}
 			stats = append(stats, sts...)
 		}
@@ -53,7 +53,7 @@ func convertConnectionStat(stat net.ConnectionStat) (Connection, error) {
 	addr, _ := netip.ParseAddr(stat.Laddr.IP)
 	port := int(stat.Laddr.Port)
 	if !addr.IsValid() || port == 0 {
-		return conn, xerrors.Errorf("invalid Laddr: %s", stat.Laddr)
+		return conn, fmt.Errorf("invalid Laddr: %s", stat.Laddr)
 	}
 	conn.LocalIP = addr
 	conn.LocalPort = port

--- a/internal/metadata/process.go
+++ b/internal/metadata/process.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/mozillazg/ptcpdump/internal/types"
 	"github.com/mozillazg/ptcpdump/internal/utils"
 	"github.com/shirou/gopsutil/v3/process"
-	"golang.org/x/xerrors"
 )
 
 const defaultProcDir = "/proc"
@@ -57,7 +57,7 @@ func (c *ProcessCache) Start(ctx context.Context) {
 func (c *ProcessCache) fillRunningProcesses(ctx context.Context) error {
 	ps, err := process.ProcessesWithContext(ctx)
 	if err != nil {
-		return xerrors.Errorf(": %w", err)
+		return fmt.Errorf(": %w", err)
 	}
 	for _, p := range ps {
 		filename, _ := p.Exe()

--- a/internal/utils/cgroup.go
+++ b/internal/utils/cgroup.go
@@ -1,10 +1,10 @@
 package utils
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"regexp"
-
-	"golang.org/x/xerrors"
 )
 
 var PathProcMounts = "/proc/mounts"
@@ -17,11 +17,11 @@ func GetCgroupV2RootDir() (string, error) {
 func getCgroupV2RootDir(pathProcMounts string) (string, error) {
 	data, err := os.ReadFile(pathProcMounts)
 	if err != nil {
-		return "", xerrors.Errorf("read file %s: %w", pathProcMounts, err)
+		return "", fmt.Errorf("read file %s: %w", pathProcMounts, err)
 	}
 	items := reCgroup2Mount.FindStringSubmatch(string(data))
 	if len(items) < 2 {
-		return "", xerrors.New("cgroupv2 is not mounted")
+		return "", errors.New("cgroupv2 is not mounted")
 	}
 	return items[1], nil
 }

--- a/internal/writer/pcap.go
+++ b/internal/writer/pcap.go
@@ -1,10 +1,11 @@
 package writer
 
 import (
+	"fmt"
+
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/pcapgo"
 	"github.com/mozillazg/ptcpdump/internal/event"
-	"golang.org/x/xerrors"
 )
 
 type PcapWriter struct {
@@ -24,7 +25,7 @@ func (w *PcapWriter) Write(e *event.Packet) error {
 		InterfaceIndex: e.Device.Ifindex,
 	}
 	if err := w.pw.WritePacket(info, e.Data); err != nil {
-		return xerrors.Errorf("writing packet: %w", err)
+		return fmt.Errorf("writing packet: %w", err)
 	}
 
 	return nil

--- a/internal/writer/pcapng.go
+++ b/internal/writer/pcapng.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mozillazg/ptcpdump/internal/event"
 	"github.com/mozillazg/ptcpdump/internal/log"
 	"github.com/mozillazg/ptcpdump/internal/metadata"
-	"golang.org/x/xerrors"
 )
 
 type PcapNGWriter struct {
@@ -54,7 +53,7 @@ func (w *PcapNGWriter) Write(e *event.Packet) error {
 	}
 
 	if err := w.pw.WritePacketWithOptions(info, e.Data, opts); err != nil {
-		return xerrors.Errorf("writing packet: %w", err)
+		return fmt.Errorf("writing packet: %w", err)
 	}
 	if w.noBuffer {
 		w.pw.Flush()


### PR DESCRIPTION
This change proposes two commits:
- internal/dev: drop vishvananda/netlink
- all: drop golang.org/x/xerrors 

Both reduce the number of dependencies as the required functionality is covered by the standard library.