### PR TITLE
fix can't filter by pod name include dot

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -100,17 +99,16 @@ func prepareOptions(opts *Options, rawArgs []string, args []string) {
 	}
 
 	if opts.podName != "" {
-		parts := strings.Split(opts.podName, ".")
-		if len(parts) > 2 {
-			logFatal(errors.New("the format of `--pod-name` should be NAME.NAMESPACE"))
-		}
-		opts.podName = parts[0]
-		if len(parts) > 1 {
-			opts.podNamespace = parts[1]
-		} else {
-			opts.podNamespace = "default"
-		}
+		opts.podName, opts.podNamespace = getPodNameFilter(opts.podName)
 	}
+}
+
+func getPodNameFilter(raw string) (name, ns string) {
+	if !strings.Contains(raw, ".") {
+		return raw, "default"
+	}
+	index := strings.LastIndex(raw, ".")
+	return raw[:index], raw[index+1:]
 }
 
 func getEndpoint(raw string) string {

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import "testing"
+
+func Test_getPodNameFilter(t *testing.T) {
+	type args struct {
+		raw string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantNs   string
+		wantName string
+	}{
+		{
+			name: "include ns and name",
+			args: args{
+				raw: "foo.bar",
+			},
+			wantName: "foo",
+			wantNs:   "bar",
+		},
+		{
+			name: "name include dot",
+			args: args{
+				raw: "foo.bar.foobar",
+			},
+			wantName: "foo.bar",
+			wantNs:   "foobar",
+		},
+		{
+			name: "default ns",
+			args: args{
+				raw: "foobar",
+			},
+			wantName: "foobar",
+			wantNs:   "default",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotNs := getPodNameFilter(tt.args.raw)
+			if gotNs != tt.wantNs {
+				t.Errorf("getPodNameFilter() gotNs = %v, want %v", gotNs, tt.wantNs)
+			}
+			if gotName != tt.wantName {
+				t.Errorf("getPodNameFilter() gotName = %v, want %v", gotName, tt.wantName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
e.g. `foo.bar.default` -> pod name: `foo.bar`, namespace: `default`