### PR TITLE
feat(output): display MPTCP options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,10 +102,9 @@ replace (
 	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.26
 	github.com/Microsoft/hcsshim/test => github.com/Microsoft/hcsshim/test v0.0.0-20210514012740-eba372547321
 	github.com/containerd/containerd => github.com/containerd/containerd v1.4.13
-	// github.com/docker/docker => github.com/docker/docker v20.10.12+incompatible
 	github.com/docker/docker => github.com/docker/docker v24.0.9+incompatible
-	github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240602032747-2b08f0c63614
-	github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240926140652-120bcf8d8890
+	github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240928025743-af4d18b65a70
+	github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240928035206-3598f58e5bfd
 
 	// https://github.com/kubernetes/kubernetes/blob/release-1.24/go.mod
 	go.opencensus.io => go.opencensus.io v0.23.0

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ replace (
 	github.com/Microsoft/hcsshim/test => github.com/Microsoft/hcsshim/test v0.0.0-20210514012740-eba372547321
 	github.com/containerd/containerd => github.com/containerd/containerd v1.4.13
 	github.com/docker/docker => github.com/docker/docker v24.0.9+incompatible
-	github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20241002124513-c32042430295
+	github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20241002125412-112c3fb39360
 	// github.com/gopacket/gopacket => ../../gopacket/gopacket
 	github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20241002124615-e03da3440378
 	// github.com/x-way/pktdump => ../../x-way/pktdump

--- a/go.mod
+++ b/go.mod
@@ -103,8 +103,10 @@ replace (
 	github.com/Microsoft/hcsshim/test => github.com/Microsoft/hcsshim/test v0.0.0-20210514012740-eba372547321
 	github.com/containerd/containerd => github.com/containerd/containerd v1.4.13
 	github.com/docker/docker => github.com/docker/docker v24.0.9+incompatible
-	github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240930124105-2e5a32c1b751
-	github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240930140149-682051b53f64
+	github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20241002124513-c32042430295
+	// github.com/gopacket/gopacket => ../../gopacket/gopacket
+	github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20241002124615-e03da3440378
+	// github.com/x-way/pktdump => ../../x-way/pktdump
 
 	// https://github.com/kubernetes/kubernetes/blob/release-1.24/go.mod
 	go.opencensus.io => go.opencensus.io v0.23.0

--- a/go.mod
+++ b/go.mod
@@ -103,8 +103,8 @@ replace (
 	github.com/Microsoft/hcsshim/test => github.com/Microsoft/hcsshim/test v0.0.0-20210514012740-eba372547321
 	github.com/containerd/containerd => github.com/containerd/containerd v1.4.13
 	github.com/docker/docker => github.com/docker/docker v24.0.9+incompatible
-	github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240928025743-af4d18b65a70
-	github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240928035206-3598f58e5bfd
+	github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240929131848-5b85f4bf5509
+	github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240930075705-eef9ebfadc19
 
 	// https://github.com/kubernetes/kubernetes/blob/release-1.24/go.mod
 	go.opencensus.io => go.opencensus.io v0.23.0

--- a/go.mod
+++ b/go.mod
@@ -103,8 +103,8 @@ replace (
 	github.com/Microsoft/hcsshim/test => github.com/Microsoft/hcsshim/test v0.0.0-20210514012740-eba372547321
 	github.com/containerd/containerd => github.com/containerd/containerd v1.4.13
 	github.com/docker/docker => github.com/docker/docker v24.0.9+incompatible
-	github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240929131848-5b85f4bf5509
-	github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240930075705-eef9ebfadc19
+	github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240930124105-2e5a32c1b751
+	github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240930140149-682051b53f64
 
 	// https://github.com/kubernetes/kubernetes/blob/release-1.24/go.mod
 	go.opencensus.io => go.opencensus.io v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -240,10 +240,10 @@ github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQB
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/mozillazg/gopacket v0.0.0-20240928025743-af4d18b65a70 h1:3ALidxejBQVNyJ9OeJZTQ6PkqgLOZNf0awD+VZwnJDo=
-github.com/mozillazg/gopacket v0.0.0-20240928025743-af4d18b65a70/go.mod h1:lnXM4VDqJTe4d2NoZr8DZMtidkhss2Y82QFlamXWfXo=
-github.com/mozillazg/pktdump v0.0.9-0.20240928035206-3598f58e5bfd h1:usHIzHrBVFsClIeDmS/d47KtZ4/BA0+ml50DBsCU4Vk=
-github.com/mozillazg/pktdump v0.0.9-0.20240928035206-3598f58e5bfd/go.mod h1:yaPxDC9ZouRs2llbxwzALIDnw216j+Qt8B/yqS35qbU=
+github.com/mozillazg/gopacket v0.0.0-20240929131848-5b85f4bf5509 h1:Oq2ZSUSg6fn638HwE9R+gEM8S87p5FKwWxALsT7/cP4=
+github.com/mozillazg/gopacket v0.0.0-20240929131848-5b85f4bf5509/go.mod h1:lnXM4VDqJTe4d2NoZr8DZMtidkhss2Y82QFlamXWfXo=
+github.com/mozillazg/pktdump v0.0.9-0.20240930075705-eef9ebfadc19 h1:WYLf7XQ+v9JmssUCXdsP1b6OyHzdTiTir1bGPrOUmBk=
+github.com/mozillazg/pktdump v0.0.9-0.20240930075705-eef9ebfadc19/go.mod h1:ULa5Pd4BSio010PwKwqVfJ3yCc1QzJamvN23g1HgKoQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/go.sum
+++ b/go.sum
@@ -240,10 +240,10 @@ github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQB
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/mozillazg/gopacket v0.0.0-20240930124105-2e5a32c1b751 h1:6KWcGaIf4JbSD6tXkpl/SHvsgVdEWt4ohIWt95n+96M=
-github.com/mozillazg/gopacket v0.0.0-20240930124105-2e5a32c1b751/go.mod h1:lnXM4VDqJTe4d2NoZr8DZMtidkhss2Y82QFlamXWfXo=
-github.com/mozillazg/pktdump v0.0.9-0.20240930140149-682051b53f64 h1:E2mNHiALtXBwqI7+tPiljE0+zdSEmWtz7O9dn2hzOPY=
-github.com/mozillazg/pktdump v0.0.9-0.20240930140149-682051b53f64/go.mod h1:Vh2MvrLyL23PaYh0Dp2Ihg6qTmNydO2su6ngpJEp/hM=
+github.com/mozillazg/gopacket v0.0.0-20241002124513-c32042430295 h1:r0k+asViiEfXIKWqMbxHNJyZnC+wiaY0gBKGLO9/+38=
+github.com/mozillazg/gopacket v0.0.0-20241002124513-c32042430295/go.mod h1:lnXM4VDqJTe4d2NoZr8DZMtidkhss2Y82QFlamXWfXo=
+github.com/mozillazg/pktdump v0.0.9-0.20241002124615-e03da3440378 h1:gySTfYsqs25cWiem+E4S51TCRSoF3bzhydPzRq1MHZ8=
+github.com/mozillazg/pktdump v0.0.9-0.20241002124615-e03da3440378/go.mod h1:Vh2MvrLyL23PaYh0Dp2Ihg6qTmNydO2su6ngpJEp/hM=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQB
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/mozillazg/gopacket v0.0.0-20241002124513-c32042430295 h1:r0k+asViiEfXIKWqMbxHNJyZnC+wiaY0gBKGLO9/+38=
-github.com/mozillazg/gopacket v0.0.0-20241002124513-c32042430295/go.mod h1:lnXM4VDqJTe4d2NoZr8DZMtidkhss2Y82QFlamXWfXo=
+github.com/mozillazg/gopacket v0.0.0-20241002125412-112c3fb39360 h1:2PG5+BKZ2bqfILNlqA8fahl6lvo/18+Q3mBJBEeLmxI=
+github.com/mozillazg/gopacket v0.0.0-20241002125412-112c3fb39360/go.mod h1:lnXM4VDqJTe4d2NoZr8DZMtidkhss2Y82QFlamXWfXo=
 github.com/mozillazg/pktdump v0.0.9-0.20241002124615-e03da3440378 h1:gySTfYsqs25cWiem+E4S51TCRSoF3bzhydPzRq1MHZ8=
 github.com/mozillazg/pktdump v0.0.9-0.20241002124615-e03da3440378/go.mod h1:Vh2MvrLyL23PaYh0Dp2Ihg6qTmNydO2su6ngpJEp/hM=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/go.sum
+++ b/go.sum
@@ -240,10 +240,10 @@ github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQB
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/mozillazg/gopacket v0.0.0-20240602032747-2b08f0c63614 h1:X92DuctbVbaRRRqpTDRW5oQd+GSAnPr1BEMNx5Z0uLo=
-github.com/mozillazg/gopacket v0.0.0-20240602032747-2b08f0c63614/go.mod h1:lnXM4VDqJTe4d2NoZr8DZMtidkhss2Y82QFlamXWfXo=
-github.com/mozillazg/pktdump v0.0.9-0.20240926140652-120bcf8d8890 h1:EjsF2dH2lupdqXLMwhDG/66/lg5sp9nqPoq2PSnjvFU=
-github.com/mozillazg/pktdump v0.0.9-0.20240926140652-120bcf8d8890/go.mod h1:InLCDK8kgkk26VtyPZ51e0igf15eiXDMvvQuV62Wqmw=
+github.com/mozillazg/gopacket v0.0.0-20240928025743-af4d18b65a70 h1:3ALidxejBQVNyJ9OeJZTQ6PkqgLOZNf0awD+VZwnJDo=
+github.com/mozillazg/gopacket v0.0.0-20240928025743-af4d18b65a70/go.mod h1:lnXM4VDqJTe4d2NoZr8DZMtidkhss2Y82QFlamXWfXo=
+github.com/mozillazg/pktdump v0.0.9-0.20240928035206-3598f58e5bfd h1:usHIzHrBVFsClIeDmS/d47KtZ4/BA0+ml50DBsCU4Vk=
+github.com/mozillazg/pktdump v0.0.9-0.20240928035206-3598f58e5bfd/go.mod h1:yaPxDC9ZouRs2llbxwzALIDnw216j+Qt8B/yqS35qbU=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/go.sum
+++ b/go.sum
@@ -240,10 +240,10 @@ github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQB
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/mozillazg/gopacket v0.0.0-20240929131848-5b85f4bf5509 h1:Oq2ZSUSg6fn638HwE9R+gEM8S87p5FKwWxALsT7/cP4=
-github.com/mozillazg/gopacket v0.0.0-20240929131848-5b85f4bf5509/go.mod h1:lnXM4VDqJTe4d2NoZr8DZMtidkhss2Y82QFlamXWfXo=
-github.com/mozillazg/pktdump v0.0.9-0.20240930075705-eef9ebfadc19 h1:WYLf7XQ+v9JmssUCXdsP1b6OyHzdTiTir1bGPrOUmBk=
-github.com/mozillazg/pktdump v0.0.9-0.20240930075705-eef9ebfadc19/go.mod h1:ULa5Pd4BSio010PwKwqVfJ3yCc1QzJamvN23g1HgKoQ=
+github.com/mozillazg/gopacket v0.0.0-20240930124105-2e5a32c1b751 h1:6KWcGaIf4JbSD6tXkpl/SHvsgVdEWt4ohIWt95n+96M=
+github.com/mozillazg/gopacket v0.0.0-20240930124105-2e5a32c1b751/go.mod h1:lnXM4VDqJTe4d2NoZr8DZMtidkhss2Y82QFlamXWfXo=
+github.com/mozillazg/pktdump v0.0.9-0.20240930140149-682051b53f64 h1:E2mNHiALtXBwqI7+tPiljE0+zdSEmWtz7O9dn2hzOPY=
+github.com/mozillazg/pktdump v0.0.9-0.20240930140149-682051b53f64/go.mod h1:Vh2MvrLyL23PaYh0Dp2Ihg6qTmNydO2su6ngpJEp/hM=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/vendor/github.com/gopacket/gopacket/layers/.lint_blacklist
+++ b/vendor/github.com/gopacket/gopacket/layers/.lint_blacklist
@@ -15,6 +15,7 @@ linux_sll.go
 llc.go
 lldp.go
 mpls.go
+multipathtcp.go
 ndp.go
 ntp.go
 ospf.go

--- a/vendor/github.com/gopacket/gopacket/layers/multipathtcp.go
+++ b/vendor/github.com/gopacket/gopacket/layers/multipathtcp.go
@@ -1,0 +1,169 @@
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"fmt"
+	"net"
+)
+
+// MPTCPSubtype represents an MPTCP subtype code.
+type MPTCPSubtype uint8
+
+// MPTCP Subtypes constonts from https://www.iana.org/assignments/tcp-parameters/tcp-parameters.xml#mptcp-option-subtypes
+const (
+	MPTCPSubtypeMPCAPABLE   = 0x0
+	MPTCPSubtypeMPJOIN      = 0x1
+	MPTCPSubtypeDSS         = 0x2
+	MPTCPSubtypeADDADDR     = 0x3
+	MPTCPSubtypeREMOVEADDR  = 0x4
+	MPTCPSubtypeMPPRIO      = 0x5
+	MPTCPSubtypeMPFAIL      = 0x6
+	MPTCPSubtypeMPFASTCLOSE = 0x7
+	MPTCPSubtypeMPTCPRST    = 0x8
+)
+
+func (k MPTCPSubtype) String() string {
+	switch k {
+	case MPTCPSubtypeMPCAPABLE:
+		return "MP_CAPABLE"
+	case MPTCPSubtypeMPJOIN:
+		return "MP_JOIN"
+	case MPTCPSubtypeDSS:
+		return "DSS"
+	case MPTCPSubtypeADDADDR:
+		return "ADD_ADDR"
+	case MPTCPSubtypeREMOVEADDR:
+		return "REMOVE_ADDR"
+	case MPTCPSubtypeMPPRIO:
+		return "MP_PRIO"
+	case MPTCPSubtypeMPFAIL:
+		return "MP_FAIL"
+	case MPTCPSubtypeMPFASTCLOSE:
+		return "MP_FASTCLOSE"
+	case MPTCPSubtypeMPTCPRST:
+		return "MP_TCPRST"
+	default:
+		return fmt.Sprintf("Unknown(%d)", k)
+	}
+}
+
+const (
+	MptcpVersion0 = 0
+	MptcpVersion1 = 1
+)
+
+const (
+	OptionLenMpCapableSyn         = 4
+	OptionLenMpCapableSynAck      = 12
+	OptionLenMpCapableAck         = 20
+	OptionLenMpCapableAckData     = 22
+	OptionLenMpCapableAckDataCSum = 24
+	OptionLenMpJoinSyn            = 12
+	OptionLenMpJoinSynAck         = 16
+	OptionLenMpJoinAck            = 24
+	OptionLenDssAck               = 4
+	OptionLenDssAck64             = 8
+	OptionLenDssDSN               = 4
+	OptionLenDssDSN64             = 8
+	OptionLenDssSSN               = 4
+	OptionLenDssDataLen           = 2
+	OptionLenDssCSum              = 2
+	OptionLenAddAddrv4            = 8
+	OptionLenAddAddrv6            = 20
+	OptionLenAddAddrPort          = 2
+	OptionLenAddAddrHmac          = 8
+	OptionLenRemAddr              = 4
+	OptionLenMpPrio               = 3
+	OptionLenMpPrioAddr           = 4
+	OptionLenMpFail               = 12
+	OptionLenMpFClose             = 12
+	OptionLenMpTcpRst             = 4
+)
+
+// MPCapable contains the fields from the MP_CAPABLE MPTCP Option
+type MPCapable struct {
+	BaseLayer
+	Version                uint8
+	Flags uint8
+	A, B, C, D, E, F, G, H bool
+	SendKey                uint64
+	ReceivKey              uint64
+	DataLength             uint16
+	Checksum               uint16
+}
+
+// MPJoin contains the fields from the MP_JOIN MPTCP Option
+type MPJoin struct {
+	BaseLayer
+	SubB uint8
+	Backup      bool
+	AddrID      uint8
+	ReceivToken uint32
+	SendRandNum uint32
+	SendHMAC    []byte
+}
+
+// Dss contains the fields from the DSS MPTCP Option
+type Dss struct {
+	BaseLayer
+	SubB uint8
+	Flags uint8
+	F, m, M, a, A bool
+	DataAck       []byte
+	DSN           []byte
+	SSN           uint32
+	DataLength    uint16
+	Checksum      uint16
+}
+
+// AddAddr contains the fields from the ADD_ADDR MPTCP Option
+type AddAddr struct {
+	BaseLayer
+	SubEcho uint8
+	IPVer    uint8
+	E        bool
+	AddrID   uint8
+	Address  net.IP
+	Port     uint16
+	SendHMAC []byte
+}
+
+// RemAddr contains the fields from the REMOVE_ADDR MPTCP Option
+type RemAddr struct {
+	BaseLayer
+	Sub uint8
+	AddrIDs []uint8
+}
+
+// MPPrio contains the fields from the MP_PRIO MPTCP Option
+type MPPrio struct {
+	BaseLayer
+	SubB uint8
+	Backup bool
+	AddrID uint8
+}
+
+// MPFail contains the fields from the MP_FAIL MPTCP Option
+type MPFail struct {
+	BaseLayer
+	DSN uint64
+}
+
+// MPFClose contains the fields from the MP_FASTCLOSE MPTCP Option
+type MPFClose struct {
+	BaseLayer
+	ReceivKey []byte
+}
+
+// MPTcpRst contains the fields from the MP_TCPRST MPTCP Option
+type MPTcpRst struct {
+	BaseLayer
+	SubB uint8
+	U, V, W, T bool
+	Reason     uint8
+}

--- a/vendor/github.com/gopacket/gopacket/layers/multipathtcp.go
+++ b/vendor/github.com/gopacket/gopacket/layers/multipathtcp.go
@@ -89,10 +89,9 @@ const (
 type MPCapable struct {
 	BaseLayer
 	Version                uint8
-	Flags uint8
 	A, B, C, D, E, F, G, H bool
-	SendKey                uint64
-	ReceivKey              uint64
+	SendKey                []byte
+	ReceivKey              []byte
 	DataLength             uint16
 	Checksum               uint16
 }
@@ -100,7 +99,6 @@ type MPCapable struct {
 // MPJoin contains the fields from the MP_JOIN MPTCP Option
 type MPJoin struct {
 	BaseLayer
-	SubB uint8
 	Backup      bool
 	AddrID      uint8
 	ReceivToken uint32
@@ -111,8 +109,6 @@ type MPJoin struct {
 // Dss contains the fields from the DSS MPTCP Option
 type Dss struct {
 	BaseLayer
-	SubB uint8
-	Flags uint8
 	F, m, M, a, A bool
 	DataAck       []byte
 	DSN           []byte
@@ -124,7 +120,6 @@ type Dss struct {
 // AddAddr contains the fields from the ADD_ADDR MPTCP Option
 type AddAddr struct {
 	BaseLayer
-	SubEcho uint8
 	IPVer    uint8
 	E        bool
 	AddrID   uint8
@@ -136,14 +131,12 @@ type AddAddr struct {
 // RemAddr contains the fields from the REMOVE_ADDR MPTCP Option
 type RemAddr struct {
 	BaseLayer
-	Sub uint8
 	AddrIDs []uint8
 }
 
 // MPPrio contains the fields from the MP_PRIO MPTCP Option
 type MPPrio struct {
 	BaseLayer
-	SubB uint8
 	Backup bool
 	AddrID uint8
 }
@@ -163,7 +156,6 @@ type MPFClose struct {
 // MPTcpRst contains the fields from the MP_TCPRST MPTCP Option
 type MPTcpRst struct {
 	BaseLayer
-	SubB uint8
 	U, V, W, T bool
 	Reason     uint8
 }

--- a/vendor/github.com/gopacket/gopacket/layers/tcp.go
+++ b/vendor/github.com/gopacket/gopacket/layers/tcp.go
@@ -350,8 +350,6 @@ OPTIONS:
 			opt.OptionMultipath = MPTCPSubtype(data[2] >> 4)
 			switch opt.OptionMultipath {
 			case MPTCPSubtypeMPCAPABLE:
-				fmt.Println(opt.OptionMultipath)
-				fmt.Println(opt.OptionLength)
 				if opt.OptionLength != OptionLenMpCapableSyn && opt.OptionLength != OptionLenMpCapableSynAck && opt.OptionLength != OptionLenMpCapableAck && opt.OptionLength != OptionLenMpCapableAckData && opt.OptionLength != OptionLenMpCapableAckDataCSum {
 					return fmt.Errorf("MP_CAPABLE bad option length %d", opt.OptionLength)
 				}

--- a/vendor/github.com/gopacket/gopacket/layers/tcp.go
+++ b/vendor/github.com/gopacket/gopacket/layers/tcp.go
@@ -355,7 +355,6 @@ OPTIONS:
 				}
 				opt.OptionMPTCPMpCapable = &MPCapable{
 					Version: data[2] & 0x0F,
-					Flags: data[3],
 					A:       data[3]&0x80 != 0,
 					B:       data[3]&0x40 != 0,
 					C:       data[3]&0x20 != 0,
@@ -366,10 +365,10 @@ OPTIONS:
 					H:       data[3]&0x01 != 0,
 				}
 				if opt.OptionLength >= OptionLenMpCapableSynAck {
-					opt.OptionMPTCPMpCapable.SendKey = binary.BigEndian.Uint64(data[4:12])
+					opt.OptionMPTCPMpCapable.SendKey = data[4:12]
 				}
 				if opt.OptionLength >= OptionLenMpCapableAck {
-					opt.OptionMPTCPMpCapable.ReceivKey = binary.BigEndian.Uint64(data[12:20])
+					opt.OptionMPTCPMpCapable.ReceivKey = data[12:20]
 				}
 				if opt.OptionLength >= OptionLenMpCapableAckData {
 					opt.OptionMPTCPMpCapable.DataLength = binary.BigEndian.Uint16(data[20:22])
@@ -384,7 +383,6 @@ OPTIONS:
 				switch opt.OptionLength {
 				case OptionLenMpJoinSyn:
 					opt.OptionMPTCPMpJoin = &MPJoin{
-						SubB: data[2],
 						Backup:      data[2]&0x01 != 0,
 						AddrID:      data[3],
 						ReceivToken: binary.BigEndian.Uint32(data[4:8]),
@@ -392,7 +390,6 @@ OPTIONS:
 					}
 				case OptionLenMpJoinSynAck:
 					opt.OptionMPTCPMpJoin = &MPJoin{
-						SubB: data[2],
 						Backup:      data[2]&0x01 != 0,
 						AddrID:      data[3],
 						SendHMAC:    data[4:12],
@@ -400,16 +397,11 @@ OPTIONS:
 					}
 				case OptionLenMpJoinAck:
 					opt.OptionMPTCPMpJoin = &MPJoin{
-						SubB: data[2],
-						Backup:      data[2]&0x01 != 0,
-						AddrID:      data[3],
 						SendHMAC: data[4:24],
 					}
 				}
 			case MPTCPSubtypeDSS:
 				opt.OptionMPTCPDss = &Dss{
-					SubB: data[2],
-					Flags: data[3],
 					F: data[3]&0x20 != 0,
 					m: data[3]&0x10 != 0,
 					M: data[3]&0x04 != 0,
@@ -462,7 +454,6 @@ OPTIONS:
 				switch mptcpVer {
 				case MptcpVersion0:
 					opt.OptionMPTCPAddAddr = &AddAddr{
-						SubEcho: data[2],
 						IPVer:  data[2] & 0x0F,
 						AddrID: data[3],
 					}
@@ -498,7 +489,6 @@ OPTIONS:
 					addrIds = append(addrIds, data[3+n])
 				}
 				opt.OptionMTCPRemAddr = &RemAddr{
-					Sub: data[2],
 					AddrIDs: addrIds,
 				}
 			case MPTCPSubtypeMPPRIO:
@@ -506,7 +496,6 @@ OPTIONS:
 					return fmt.Errorf("MP_PRIO bad option length %d", opt.OptionLength)
 				}
 				opt.OptionMPTCPMpPrio = &MPPrio{
-					SubB: data[2],
 					Backup: data[2]&0x01 != 0,
 				}
 				if opt.OptionLength == OptionLenMpPrioAddr {
@@ -532,7 +521,6 @@ OPTIONS:
 					return fmt.Errorf("MP_TCPRST bad option length %d", opt.OptionLength)
 				}
 				opt.OptionMPTCPMPTcpRst = &MPTcpRst{
-					SubB: data[2],
 					U:      data[2]&0x10 != 0,
 					V:      data[2]&0x04 != 0,
 					W:      data[2]&0x02 != 0,

--- a/vendor/github.com/gopacket/gopacket/layers/tcp.go
+++ b/vendor/github.com/gopacket/gopacket/layers/tcp.go
@@ -31,12 +31,14 @@ type TCP struct {
 	Options                                    []TCPOption
 	Padding                                    []byte
 	opts                                       [4]TCPOption
+	Multipath                                  bool
 	tcpipchecksum
 }
 
 // TCPOptionKind represents a TCP option code.
 type TCPOptionKind uint8
 
+// TCP Option Kind constonts from https://www.iana.org/assignments/tcp-parameters/tcp-parameters.xml#tcp-parameters-1
 const (
 	TCPOptionKindEndList                         = 0
 	TCPOptionKindNop                             = 1
@@ -54,6 +56,7 @@ const (
 	TCPOptionKindCCEcho                          = 13 // obsolete
 	TCPOptionKindAltChecksum                     = 14 // len = 3, obsolete
 	TCPOptionKindAltChecksumData                 = 15 // len = n, obsolete
+	TCPOptionKindMultipathTCP                    = 30
 )
 
 func (k TCPOptionKind) String() string {
@@ -90,15 +93,28 @@ func (k TCPOptionKind) String() string {
 		return "AltChecksum"
 	case TCPOptionKindAltChecksumData:
 		return "AltChecksumData"
+	case TCPOptionKindMultipathTCP:
+		return "MultipathTCP"
 	default:
 		return fmt.Sprintf("Unknown(%d)", k)
 	}
 }
 
+// TCPOption are the possible TCP and MPTCP Options
 type TCPOption struct {
-	OptionType   TCPOptionKind
-	OptionLength uint8
-	OptionData   []byte
+	OptionType            TCPOptionKind
+	OptionLength          uint8
+	OptionData            []byte
+	OptionMultipath       MPTCPSubtype
+	OptionMPTCPMpCapable  *MPCapable
+	OptionMPTCPDss        *Dss
+	OptionMPTCPMpJoin     *MPJoin
+	OptionMPTCPMpPrio     *MPPrio
+	OptionMPTCPAddAddr    *AddAddr
+	OptionMTCPRemAddr     *RemAddr
+	OptionMTCPMPFastClose *MPFClose
+	OptionMPTCPMPTcpRst   *MPTcpRst
+	OptionMTCPMPFail      *MPFail
 }
 
 func (t TCPOption) String() string {
@@ -122,6 +138,48 @@ func (t TCPOption) String() string {
 				binary.BigEndian.Uint32(t.OptionData[:4]),
 				binary.BigEndian.Uint32(t.OptionData[4:8]),
 				hd)
+		}
+
+	case TCPOptionKindMultipathTCP:
+		switch t.OptionMultipath {
+		case MPTCPSubtypeMPCAPABLE:
+			return fmt.Sprintf("MPTCPOption(%s Version %v)",
+				t.OptionMultipath,
+				t.OptionMPTCPMpCapable.Version)
+		case MPTCPSubtypeMPJOIN:
+			return fmt.Sprintf("MPTCPOption(%s Backup %v;Address ID %v)",
+				t.OptionMultipath,
+				t.OptionMPTCPMpJoin.Backup,
+				t.OptionMPTCPMpJoin.AddrID)
+		case MPTCPSubtypeDSS:
+			return fmt.Sprintf("MPTCPOption(%s)",
+				t.OptionMultipath)
+		case MPTCPSubtypeMPPRIO:
+			return fmt.Sprintf("MPTCPOption(%s Backup %v;Address ID %v)",
+				t.OptionMultipath,
+				t.OptionMPTCPMpPrio.Backup,
+				t.OptionMPTCPMpPrio.AddrID)
+		case MPTCPSubtypeADDADDR:
+			return fmt.Sprintf("MPTCPOption(%s Address ID %v;Address %v;Port %v)",
+				t.OptionMultipath,
+				t.OptionMPTCPAddAddr.AddrID,
+				t.OptionMPTCPAddAddr.Address,
+				t.OptionMPTCPAddAddr.Port)
+		case MPTCPSubtypeREMOVEADDR:
+			return fmt.Sprintf("MPTCPOption(%s Address ID %v)",
+				t.OptionMultipath,
+				t.OptionMTCPRemAddr.AddrIDs)
+		case MPTCPSubtypeMPFASTCLOSE:
+			return fmt.Sprintf("MPTCPOption(%s)",
+				t.OptionMultipath)
+		case MPTCPSubtypeMPTCPRST:
+			return fmt.Sprintf("MPTCPOption(%s Transient %v; Reason %v)",
+				t.OptionMultipath,
+				t.OptionMPTCPMPTcpRst.T,
+				t.OptionMPTCPMPTcpRst.Reason)
+		case MPTCPSubtypeMPFAIL:
+			return fmt.Sprintf("MPTCPOption(%s)",
+				t.OptionMultipath)
 		}
 	}
 	return fmt.Sprintf("TCPOption(%s:%s)", t.OptionType, hd)
@@ -286,6 +344,202 @@ OPTIONS:
 			break OPTIONS
 		case TCPOptionKindNop: // 1 byte padding
 			opt.OptionLength = 1
+		case TCPOptionKindMultipathTCP:
+			tcp.Multipath = true
+			opt.OptionLength = data[1]
+			opt.OptionMultipath = MPTCPSubtype(data[2] >> 4)
+			switch opt.OptionMultipath {
+			case MPTCPSubtypeMPCAPABLE:
+				if opt.OptionLength != OptionLenMpCapableSyn && opt.OptionLength != OptionLenMpCapableSynAck && opt.OptionLength != OptionLenMpCapableAck && opt.OptionLength != OptionLenMpCapableAckData {
+					return fmt.Errorf("MP_CAPABLE bad option length %d", opt.OptionLength)
+				}
+				opt.OptionMPTCPMpCapable = &MPCapable{
+					Version: data[2] & 0x0F,
+					Flags: data[3],
+					A:       data[3]&0x80 != 0,
+					B:       data[3]&0x40 != 0,
+					C:       data[3]&0x20 != 0,
+					D:       data[3]&0x10 != 0,
+					E:       data[3]&0x08 != 0,
+					F:       data[3]&0x04 != 0,
+					G:       data[3]&0x02 != 0,
+					H:       data[3]&0x01 != 0,
+				}
+				if opt.OptionLength >= OptionLenMpCapableSynAck {
+					opt.OptionMPTCPMpCapable.SendKey = binary.BigEndian.Uint64(data[4:12])
+				}
+				if opt.OptionLength >= OptionLenMpCapableAck {
+					opt.OptionMPTCPMpCapable.ReceivKey = binary.BigEndian.Uint64(data[12:20])
+				}
+				if opt.OptionLength >= OptionLenMpCapableAckData {
+					opt.OptionMPTCPMpCapable.DataLength = binary.BigEndian.Uint16(data[20:22])
+				}
+				if opt.OptionLength == OptionLenMpCapableAckDataCSum {
+					opt.OptionMPTCPMpCapable.Checksum = binary.BigEndian.Uint16(data[22:24])
+				}
+			case MPTCPSubtypeMPJOIN:
+				if opt.OptionLength != OptionLenMpJoinSyn && opt.OptionLength != OptionLenMpJoinSynAck && opt.OptionLength != OptionLenMpJoinAck {
+					return fmt.Errorf("MP_JOIN bad option length %d", opt.OptionLength)
+				}
+				switch opt.OptionLength {
+				case OptionLenMpJoinSyn:
+					opt.OptionMPTCPMpJoin = &MPJoin{
+						SubB: data[2],
+						Backup:      data[2]&0x01 != 0,
+						AddrID:      data[3],
+						ReceivToken: binary.BigEndian.Uint32(data[4:8]),
+						SendRandNum: binary.BigEndian.Uint32(data[8:12]),
+					}
+				case OptionLenMpJoinSynAck:
+					opt.OptionMPTCPMpJoin = &MPJoin{
+						SubB: data[2],
+						Backup:      data[2]&0x01 != 0,
+						AddrID:      data[3],
+						SendHMAC:    data[4:12],
+						SendRandNum: binary.BigEndian.Uint32(data[12:16]),
+					}
+				case OptionLenMpJoinAck:
+					opt.OptionMPTCPMpJoin = &MPJoin{
+						SubB: data[2],
+						Backup:      data[2]&0x01 != 0,
+						AddrID:      data[3],
+						SendHMAC: data[4:24],
+					}
+				}
+			case MPTCPSubtypeDSS:
+				opt.OptionMPTCPDss = &Dss{
+					SubB: data[2],
+					Flags: data[3],
+					F: data[3]&0x20 != 0,
+					m: data[3]&0x10 != 0,
+					M: data[3]&0x04 != 0,
+					a: data[3]&0x02 != 0,
+					A: data[3]&0x01 != 0,
+				}
+				if opt.OptionLength != optionMptcpDsslen(opt.OptionMPTCPDss, false) && opt.OptionLength != optionMptcpDsslen(opt.OptionMPTCPDss, true) {
+					return fmt.Errorf("DSS bad option length %d", opt.OptionLength)
+				}
+				var lenOpt uint8 = 4
+				if opt.OptionMPTCPDss.A { // Data ACK present
+					if opt.OptionMPTCPDss.a { // Data ACK is 8 octets
+						opt.OptionMPTCPDss.DataAck = data[lenOpt : lenOpt+OptionLenDssAck64]
+						lenOpt += OptionLenDssAck64
+					} else {
+						opt.OptionMPTCPDss.DataAck = data[lenOpt : lenOpt+OptionLenDssAck]
+						lenOpt += OptionLenDssAck
+					}
+				}
+				if opt.OptionMPTCPDss.M { // Data Sequence Number (DSN), Subflow Sequence Number (SSN), Data-Level Length, and Checksum (if negotiated) present
+					if opt.OptionMPTCPDss.a { // Data Sequence Number is 8 octets
+						opt.OptionMPTCPDss.DSN = data[lenOpt : lenOpt+OptionLenDssDSN64]
+						lenOpt += OptionLenDssDSN64
+					} else {
+						opt.OptionMPTCPDss.DSN = data[lenOpt : lenOpt+OptionLenDssDSN]
+						lenOpt += OptionLenDssDSN
+					}
+					opt.OptionMPTCPDss.SSN = binary.BigEndian.Uint32(data[lenOpt : lenOpt+OptionLenDssSSN])
+					lenOpt += OptionLenDssSSN
+					opt.OptionMPTCPDss.DataLength = binary.BigEndian.Uint16(data[lenOpt : lenOpt+OptionLenDssDataLen])
+					lenOpt += OptionLenDssDataLen
+					if opt.OptionLength-lenOpt == 2 { // Checksum present
+						opt.OptionMPTCPDss.Checksum = binary.BigEndian.Uint16(data[lenOpt : lenOpt+OptionLenDssCSum])
+					}
+				}
+			case MPTCPSubtypeADDADDR:
+				var mptcpVer uint8
+				var bitE bool
+				lenOpt := opt.OptionLength
+
+				if data[2]&0x0F > 1 {
+					mptcpVer = MptcpVersion0
+				} else {
+					mptcpVer = MptcpVersion1
+					bitE = data[2]&0x01 != 0
+				}
+				if !isValidOptionMptcpAddAddrlen(opt.OptionLength, mptcpVer, bitE) {
+					return fmt.Errorf("ADD_ADDR bad option length %d", opt.OptionLength)
+				}
+				switch mptcpVer {
+				case MptcpVersion0:
+					opt.OptionMPTCPAddAddr = &AddAddr{
+						SubEcho: data[2],
+						IPVer:  data[2] & 0x0F,
+						AddrID: data[3],
+					}
+				case MptcpVersion1:
+					opt.OptionMPTCPAddAddr = &AddAddr{
+						E:      data[2]&0x01 != 0,
+						AddrID: data[3],
+					}
+					if !opt.OptionMPTCPAddAddr.E {
+						opt.OptionMPTCPAddAddr.SendHMAC = data[opt.OptionLength-8:]
+						lenOpt -= OptionLenAddAddrHmac
+					}
+				}
+				switch lenOpt {
+				case OptionLenAddAddrv4:
+					opt.OptionMPTCPAddAddr.Address = data[4:8]
+				case OptionLenAddAddrv4 + OptionLenAddAddrPort:
+					opt.OptionMPTCPAddAddr.Address = data[4:8]
+					opt.OptionMPTCPAddAddr.Port = binary.BigEndian.Uint16(data[8:10])
+				case OptionLenAddAddrv6:
+					opt.OptionMPTCPAddAddr.Address = data[4:20]
+				case OptionLenAddAddrv6 + OptionLenAddAddrPort:
+					opt.OptionMPTCPAddAddr.Address = data[4:20]
+					opt.OptionMPTCPAddAddr.Port = binary.BigEndian.Uint16(data[20:22])
+				}
+			case MPTCPSubtypeREMOVEADDR:
+				if opt.OptionLength < OptionLenRemAddr {
+					return fmt.Errorf("Rem_ADDR bad option length %d", opt.OptionLength)
+				}
+				var addrIds []uint8
+				var n uint8
+				for n = 0; n < opt.OptionLength-3; n++ {
+					addrIds = append(addrIds, data[3+n])
+				}
+				opt.OptionMTCPRemAddr = &RemAddr{
+					Sub: data[2],
+					AddrIDs: addrIds,
+				}
+			case MPTCPSubtypeMPPRIO:
+				if opt.OptionLength != OptionLenMpPrio && opt.OptionLength != OptionLenMpPrioAddr {
+					return fmt.Errorf("MP_PRIO bad option length %d", opt.OptionLength)
+				}
+				opt.OptionMPTCPMpPrio = &MPPrio{
+					SubB: data[2],
+					Backup: data[2]&0x01 != 0,
+				}
+				if opt.OptionLength == OptionLenMpPrioAddr {
+					opt.OptionMPTCPMpPrio.AddrID = data[3]
+				}
+			case MPTCPSubtypeMPFAIL:
+				if opt.OptionLength != OptionLenMpFail {
+					return fmt.Errorf("MP_FAIL bad option length %d", opt.OptionLength)
+				}
+				opt.OptionMTCPMPFail = &MPFail{
+					DSN: binary.BigEndian.Uint64(data[4:OptionLenMpFail]),
+				}
+
+			case MPTCPSubtypeMPFASTCLOSE:
+				if opt.OptionLength != OptionLenMpFClose {
+					return fmt.Errorf("MP_FASTCLOSE bad option length %d", opt.OptionLength)
+				}
+				opt.OptionMTCPMPFastClose = &MPFClose{
+					ReceivKey: data[4:OptionLenMpFClose],
+				}
+			case MPTCPSubtypeMPTCPRST:
+				if opt.OptionLength != OptionLenMpTcpRst {
+					return fmt.Errorf("MP_TCPRST bad option length %d", opt.OptionLength)
+				}
+				opt.OptionMPTCPMPTcpRst = &MPTcpRst{
+					SubB: data[2],
+					U:      data[2]&0x10 != 0,
+					V:      data[2]&0x04 != 0,
+					W:      data[2]&0x02 != 0,
+					T:      data[2]&0x01 != 0,
+					Reason: data[3],
+				}
+			}
 		default:
 			if len(data) < 2 {
 				df.SetTruncated()
@@ -303,6 +557,40 @@ OPTIONS:
 		data = data[opt.OptionLength:]
 	}
 	return nil
+}
+
+func optionMptcpDsslen(OptionMPTCPDss *Dss, csum bool) uint8 {
+	var len uint8 = 4
+	if OptionMPTCPDss.A { // Data ACK
+		len += 4
+		if OptionMPTCPDss.a {
+			len += 4
+		} // Data ACK 8 octets
+	}
+	if OptionMPTCPDss.M { // DSN (4)+ SSN (4) + Data-Level Length (2) = 10
+		len += 10
+		if OptionMPTCPDss.m {
+			len += 4
+		} // DSN 8 octets
+		if csum {
+			len += 2
+		}
+	}
+	return len
+}
+
+func isValidOptionMptcpAddAddrlen(length uint8, mptcpVer uint8, hmac bool) bool {
+	var ret bool
+	switch mptcpVer {
+	case MptcpVersion0:
+		ret = length == OptionLenAddAddrv4 || length == OptionLenAddAddrv4+OptionLenAddAddrPort || length == OptionLenAddAddrv6 || length == OptionLenAddAddrv6+OptionLenAddAddrPort
+	case MptcpVersion1:
+		if !hmac {
+			length -= OptionLenAddAddrHmac
+		}
+		ret = length == OptionLenAddAddrv4 || length == OptionLenAddAddrv4+OptionLenAddAddrPort || length == OptionLenAddAddrv6 || length == OptionLenAddAddrv6+OptionLenAddAddrPort
+	}
+	return ret
 }
 
 func (t *TCP) CanDecode() gopacket.LayerClass {

--- a/vendor/github.com/gopacket/gopacket/layers/tcp.go
+++ b/vendor/github.com/gopacket/gopacket/layers/tcp.go
@@ -350,7 +350,9 @@ OPTIONS:
 			opt.OptionMultipath = MPTCPSubtype(data[2] >> 4)
 			switch opt.OptionMultipath {
 			case MPTCPSubtypeMPCAPABLE:
-				if opt.OptionLength != OptionLenMpCapableSyn && opt.OptionLength != OptionLenMpCapableSynAck && opt.OptionLength != OptionLenMpCapableAck && opt.OptionLength != OptionLenMpCapableAckData {
+				fmt.Println(opt.OptionMultipath)
+				fmt.Println(opt.OptionLength)
+				if opt.OptionLength != OptionLenMpCapableSyn && opt.OptionLength != OptionLenMpCapableSynAck && opt.OptionLength != OptionLenMpCapableAck && opt.OptionLength != OptionLenMpCapableAckData && opt.OptionLength != OptionLenMpCapableAckDataCSum {
 					return fmt.Errorf("MP_CAPABLE bad option length %d", opt.OptionLength)
 				}
 				opt.OptionMPTCPMpCapable = &MPCapable{
@@ -521,7 +523,7 @@ OPTIONS:
 					return fmt.Errorf("MP_TCPRST bad option length %d", opt.OptionLength)
 				}
 				opt.OptionMPTCPMPTcpRst = &MPTcpRst{
-					U:      data[2]&0x10 != 0,
+					U:      data[2]&0x08 != 0,
 					V:      data[2]&0x04 != 0,
 					W:      data[2]&0x02 != 0,
 					T:      data[2]&0x01 != 0,

--- a/vendor/github.com/gopacket/gopacket/layers/tcp.go
+++ b/vendor/github.com/gopacket/gopacket/layers/tcp.go
@@ -402,8 +402,8 @@ OPTIONS:
 				}
 			case MPTCPSubtypeDSS:
 				opt.OptionMPTCPDss = &Dss{
-					F: data[3]&0x20 != 0,
-					m: data[3]&0x10 != 0,
+					F: data[3]&0x10 != 0,
+					m: data[3]&0x08 != 0,
 					M: data[3]&0x04 != 0,
 					a: data[3]&0x02 != 0,
 					A: data[3]&0x01 != 0,
@@ -422,7 +422,7 @@ OPTIONS:
 					}
 				}
 				if opt.OptionMPTCPDss.M { // Data Sequence Number (DSN), Subflow Sequence Number (SSN), Data-Level Length, and Checksum (if negotiated) present
-					if opt.OptionMPTCPDss.a { // Data Sequence Number is 8 octets
+					if opt.OptionMPTCPDss.m { // Data Sequence Number is 8 octets
 						opt.OptionMPTCPDss.DSN = data[lenOpt : lenOpt+OptionLenDssDSN64]
 						lenOpt += OptionLenDssDSN64
 					} else {

--- a/vendor/github.com/x-way/pktdump/format.go
+++ b/vendor/github.com/x-way/pktdump/format.go
@@ -80,6 +80,8 @@ func formatPacketTCP(tcp *layers.TCP, src, dst string, length int, style FormatS
 				out += "sackOK"
 			case layers.TCPOptionKindTimestamps:
 				out += fmt.Sprintf("TS val %d ecr %d", binary.BigEndian.Uint32(opt.OptionData[:4]), binary.BigEndian.Uint32(opt.OptionData[4:8]))
+			case layers.TCPOptionKindMultipathTCP:
+				out += formatMPTCP(opt)
 			default:
 				out += fmt.Sprintf("unknown-%d", opt.OptionType)
 				if len(opt.OptionData) > 0 {

--- a/vendor/github.com/x-way/pktdump/mptcp.go
+++ b/vendor/github.com/x-way/pktdump/mptcp.go
@@ -211,32 +211,36 @@ func mpCapablePrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *strin
 	}
 
 	var flags []string
-	switch {
-	case opt.OptionMPTCPMpCapable.A:
+	if opt.OptionMPTCPMpCapable.A {
 		flags = append(flags, "A")
-	case opt.OptionMPTCPMpCapable.B:
+	}
+	if opt.OptionMPTCPMpCapable.B {
 		flags = append(flags, "B")
-	case opt.OptionMPTCPMpCapable.C:
+	}
+	if opt.OptionMPTCPMpCapable.C {
 		flags = append(flags, "C")
-	case opt.OptionMPTCPMpCapable.D:
+	}
+	if opt.OptionMPTCPMpCapable.D {
 		flags = append(flags, "D")
-	case opt.OptionMPTCPMpCapable.E:
+	}
+	if opt.OptionMPTCPMpCapable.E {
 		flags = append(flags, "E")
-	case opt.OptionMPTCPMpCapable.F:
+	}
+	if opt.OptionMPTCPMpCapable.F {
 		flags = append(flags, "F")
-	case opt.OptionMPTCPMpCapable.G:
+	}
+	if opt.OptionMPTCPMpCapable.G {
 		flags = append(flags, "G")
-	case opt.OptionMPTCPMpCapable.H:
+	}
+	if opt.OptionMPTCPMpCapable.H {
 		flags = append(flags, "H")
 	}
 
-	flagsStr := strings.Join(flags, " ")
+	flagsStr := strings.Join(flags, "")
 	if flagsStr == "" {
 		flagsStr = "none"
 	}
-	if flagsStr != "A" {
-		buf.WriteString(fmt.Sprintf(" flags [%s]", flagsStr))
-	}
+	buf.WriteString(fmt.Sprintf(" flags [%s]", flagsStr))
 
 	csumEnabled := opt.OptionMPTCPMpCapable.A
 	if csumEnabled {
@@ -436,17 +440,19 @@ func mpTCPRSTPrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *string
 	mpr.Reason = opt.OptionMPTCPMPTcpRst.Reason
 
 	var flags []string
-	switch {
-	case opt.OptionMPTCPMPTcpRst.T:
+	if opt.OptionMPTCPMPTcpRst.T {
 		flags = append(flags, "T")
-	case opt.OptionMPTCPMPTcpRst.U:
+	}
+	if opt.OptionMPTCPMPTcpRst.U {
 		flags = append(flags, "U")
-	case opt.OptionMPTCPMPTcpRst.V:
+	}
+	if opt.OptionMPTCPMPTcpRst.V {
 		flags = append(flags, "V")
-	case opt.OptionMPTCPMPTcpRst.W:
+	}
+	if opt.OptionMPTCPMPTcpRst.W {
 		flags = append(flags, "W")
 	}
-	flagsStr := strings.Join(flags, " ")
+	flagsStr := strings.Join(flags, "")
 	if flagsStr == "" {
 		flagsStr = "none"
 	}
@@ -517,12 +523,14 @@ func bittok2str(tokens []Token, defaultStr string, value uint32) string {
 }
 
 func bytesToUint64(b []byte) uint64 {
-	switch len(b) {
-	case 8:
+	length := len(b)
+	if length >= 8 {
 		return binary.BigEndian.Uint64(b)
-	case 4:
+	}
+	if length == 4 {
 		return uint64(binary.BigEndian.Uint32(b))
-	case 2:
+	}
+	if length == 2 {
 		return uint64(binary.BigEndian.Uint16(b))
 	}
 	return 0

--- a/vendor/github.com/x-way/pktdump/mptcp.go
+++ b/vendor/github.com/x-way/pktdump/mptcp.go
@@ -1,0 +1,663 @@
+package pktdump
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/gopacket/gopacket/layers"
+	"strings"
+)
+
+// Token represents a value-string pair for lookup.
+type Token struct {
+	Value uint32
+	Str   string
+}
+
+// tok2str converts a token value to a string, using the provided lookup table and a fallback format.
+func tok2str(tokens []Token, fmts string, value uint32) string {
+	for _, token := range tokens {
+		if token.Value == value {
+			return token.Str
+		}
+	}
+	return fmt.Sprintf(fmts, value)
+}
+
+// MPTCPSub represents the subtype of an MPTCP option.
+type MPTCPSub uint8
+
+const (
+	MPTCPSubCapable    MPTCPSub = 0x0
+	MPTCPSubJoin       MPTCPSub = 0x1
+	MPTCPSubDSS        MPTCPSub = 0x2
+	MPTCPSubAddAddr    MPTCPSub = 0x3
+	MPTCPSubRemoveAddr MPTCPSub = 0x4
+	MPTCPSubPrio       MPTCPSub = 0x5
+	MPTCPSubFail       MPTCPSub = 0x6
+	MPTCPSubFClose     MPTCPSub = 0x7
+	MPTCPSubTCPRST     MPTCPSub = 0x8
+)
+
+// MPTCPOption represents an MPTCP option.
+type MPTCPOption struct {
+	Kind   uint8
+	Len    uint8
+	SubEtc uint8 // subtype upper 4 bits, other stuff lower 4 bits
+}
+
+// MPTCPSubKind returns the subtype of the MPTCP option.
+func (o *MPTCPOption) MPTCPSubKind() MPTCPSub {
+	return MPTCPSub((o.SubEtc >> 4) & 0xF)
+}
+
+// MP_CAPABLE_A is a flag for the "capable" option.
+const MP_CAPABLE_A = 0x80
+
+// MPCapableFlags represents the flags for the "capable" option.
+var MPCapableFlags = []Token{
+	{MP_CAPABLE_A, "A"},
+	{0x40, "B"},
+	{0x20, "C"},
+	{0x10, "D"},
+	{0x08, "E"},
+	{0x04, "F"},
+	{0x02, "G"},
+	{0x01, "H"},
+}
+
+// MPCapable represents the "capable" option data.
+type MPCapable struct {
+	Kind        uint8
+	Len         uint8
+	SubVer      uint8
+	Flags       uint8
+	SenderKey   uint64
+	ReceiverKey uint64
+	DataLen     uint16
+}
+
+// MP_CAPABLE_OPT_VERSION returns the version from the "capable" option subtype.
+func MP_CAPABLE_OPT_VERSION(subVer uint8) uint8 {
+	return (subVer >> 0) & 0xF
+}
+
+// MPJoin represents the "join" option data.
+type MPJoin struct {
+	Kind   uint8
+	Len    uint8
+	SubB   uint8
+	AddrID uint8
+	U      struct {
+		Syn struct {
+			Token uint32
+			Nonce uint32
+		}
+		SynAck struct {
+			Mac   uint64
+			Nonce uint32
+		}
+		Ack struct {
+			Mac [20]byte
+		}
+	}
+}
+
+// MP_JOIN_B is a flag for the "join" option.
+const MP_JOIN_B = 0x01
+
+// MPDSS represents the "dss" option data.
+type MPDSS struct {
+	Kind  uint8
+	Len   uint8
+	Sub   uint8
+	Flags uint8
+}
+
+// MP_DSS_F is a flag for the "dss" option.
+const MP_DSS_F = 0x10
+
+// MP_DSS_m is a flag for the "dss" option.
+const MP_DSS_m = 0x08
+
+// MP_DSS_M is a flag for the "dss" option.
+const MP_DSS_M = 0x04
+
+// MP_DSS_a is a flag for the "dss" option.
+const MP_DSS_a = 0x02
+
+// MP_DSS_A is a flag for the "dss" option.
+const MP_DSS_A = 0x01
+
+// MPTCPAddrSubEchoBits represents the subtype/echo bits for the "add-addr" option.
+var MPTCPAddrSubEchoBits = []Token{
+	{0x6, "v0-ip6"},
+	{0x4, "v0-ip4"},
+	{0x1, "v1-echo"},
+	{0x0, "v1"},
+}
+
+// MPAddAddr represents the "add-addr" option data.
+type MPAddAddr struct {
+	Kind    uint8
+	Len     uint8
+	SubEcho uint8
+	AddrID  uint8
+	U       struct {
+		V4 struct {
+			Addr uint32
+			Port uint16
+			Mac  uint64
+		}
+		V4NP struct {
+			Addr uint32
+			Mac  uint64
+		}
+		V6 struct {
+			Addr [16]byte
+			Port uint16
+			Mac  uint64
+		}
+		V6NP struct {
+			Addr [16]byte
+			Mac  uint64
+		}
+	}
+}
+
+// MPRemoveAddr represents the "rem-addr" option data.
+type MPRemoveAddr struct {
+	Kind    uint8
+	Len     uint8
+	Sub     uint8
+	AddrsID []uint8 // list of addr_id
+}
+
+// MPFail represents the "fail" option data.
+type MPFail struct {
+	Kind    uint8
+	Len     uint8
+	Sub     uint8
+	Resv    uint8
+	DataSeq uint64
+}
+
+// MPClose represents the "fast-close" option data.
+type MPClose struct {
+	Kind uint8
+	Len  uint8
+	Sub  uint8
+	Rsv  uint8
+	Key  [8]byte
+}
+
+// MPPrio represents the "prio" option data.
+type MPPrio struct {
+	Kind   uint8
+	Len    uint8
+	SubB   uint8
+	AddrID uint8
+}
+
+// MP_PRIO_B is a flag for the "prio" option.
+const MP_PRIO_B = 0x01
+
+// MPTCPFlags represents the flags for the "tcprst" option.
+var MPTCPFlags = []Token{
+	{0x08, "U"},
+	{0x04, "V"},
+	{0x02, "W"},
+	{0x01, "T"},
+}
+
+// MPTCPRSTReasons represents the reasons for the "tcprst" option.
+var MPTCPRSTReasons = []Token{
+	{0x06, "Middlebox interference"},
+	{0x05, "Unacceptable performance"},
+	{0x04, "Too much outstanding data"},
+	{0x03, "Administratively prohibited"},
+	{0x02, "Lack of resources"},
+	{0x01, "MPTCP-specific error"},
+	{0x00, "Unspecified error"},
+}
+
+// MPTCPRST represents the "tcprst" option data.
+type MPTCPRST struct {
+	Kind   uint8
+	Len    uint8
+	SubB   uint8
+	Reason uint8
+}
+
+// dummyPrint is a placeholder print function for unknown options.
+func dummyPrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *strings.Builder) error {
+	return nil
+}
+
+// mpCapablePrint prints the "capable" option.
+func mpCapablePrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *strings.Builder) error {
+	mpc := MPCapable{}
+	mpc.Kind = uint8(opt.OptionType)
+	mpc.Len = opt.OptionLength
+	mpc.SubVer = opt.OptionMPTCPMpCapable.Version
+	mpc.Flags = opt.OptionMPTCPMpCapable.Flags
+	mpc.SenderKey = opt.OptionMPTCPMpCapable.SendKey
+	mpc.ReceiverKey = opt.OptionMPTCPMpCapable.ReceivKey
+	mpc.DataLen = opt.OptionMPTCPMpCapable.DataLength
+	optLen := opt.OptionLength
+
+	version := MP_CAPABLE_OPT_VERSION(mpc.SubVer)
+	switch version {
+	case 0, 1:
+		buf.WriteString(fmt.Sprintf(" v%d", version))
+	default:
+		return fmt.Errorf("unknown version: %d", version)
+	}
+
+	flagsStr := bittok2str(MPCapableFlags, "none", uint32(mpc.Flags))
+	buf.WriteString(fmt.Sprintf(" flags [%s]", flagsStr))
+
+	csumEnabled := mpc.Flags&MP_CAPABLE_A != 0
+	if csumEnabled {
+		buf.WriteString(fmt.Sprintf(" csum"))
+	}
+
+	if optLen >= 12 {
+		buf.WriteString(fmt.Sprintf(" {0x%x", mpc.SenderKey))
+		if optLen >= 20 {
+			buf.WriteString(fmt.Sprintf(",0x%x", mpc.ReceiverKey))
+		}
+		if (optLen == 22 && !csumEnabled) || optLen == 24 {
+			buf.WriteString(fmt.Sprintf(",data_len=%d", mpc.DataLen))
+		}
+		buf.WriteString(fmt.Sprintf("}"))
+	}
+
+	return nil
+}
+
+// mpJoinPrint prints the "join" option.
+func mpJoinPrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *strings.Builder) error {
+	mpj := MPJoin{}
+	mpj.Kind = uint8(opt.OptionType)
+	mpj.Len = opt.OptionLength
+	mpj.SubB = opt.OptionMPTCPMpJoin.SubB
+	mpj.AddrID = opt.OptionMPTCPMpJoin.AddrID
+	optLen := opt.OptionLength
+
+	if optLen != 24 {
+		if mpj.SubB&MP_JOIN_B != 0 {
+			buf.WriteString(fmt.Sprintf(" backup"))
+		}
+		buf.WriteString(fmt.Sprintf(" id %d", mpj.AddrID))
+	}
+
+	switch optLen {
+	case 12: // SYN
+		mpj.U.Syn.Token = opt.OptionMPTCPMpJoin.ReceivToken
+		mpj.U.Syn.Nonce = opt.OptionMPTCPMpJoin.SendRandNum
+		buf.WriteString(fmt.Sprintf(" token 0x%x nonce 0x%x", mpj.U.Syn.Token, mpj.U.Syn.Nonce))
+	case 16: // SYN/ACK
+		mpj.U.SynAck.Mac = binary.BigEndian.Uint64(opt.OptionMPTCPMpJoin.SendHMAC)
+		mpj.U.Syn.Nonce = opt.OptionMPTCPMpJoin.SendRandNum
+		buf.WriteString(fmt.Sprintf(" hmac 0x%x nonce 0x%x", mpj.U.SynAck.Mac, mpj.U.SynAck.Nonce))
+	case 24: // ACK
+		copy(mpj.U.Ack.Mac[:], opt.OptionMPTCPMpJoin.SendHMAC)
+		buf.WriteString(fmt.Sprintf(" hmac 0x"))
+		for i := 0; i < len(mpj.U.Ack.Mac); i++ {
+			buf.WriteString(fmt.Sprintf("%02x", mpj.U.Ack.Mac[i]))
+		}
+	default:
+		return fmt.Errorf("invalid length for join option: %d", optLen)
+	}
+
+	return nil
+}
+
+var TH_SYN uint8 = (0x02)
+
+// mpDSSPrint prints the "dss" option.
+func mpDSSPrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *strings.Builder) error {
+	mdss := MPDSS{}
+	mdss.Kind = uint8(opt.OptionType)
+	mdss.Len = opt.OptionLength
+	mdss.Sub = opt.OptionMPTCPDss.SubB
+	mdss.Flags = opt.OptionMPTCPDss.Flags
+	optLen := opt.OptionLength
+
+	if optLen < 4 {
+		return fmt.Errorf("invalid length for dss option: %d", optLen)
+	}
+
+	//if flags&TH_SYN != 0 {
+	//	return fmt.Errorf("dss option not allowed with SYN flag")
+	//}
+
+	if mdss.Flags&MP_DSS_F != 0 {
+		buf.WriteString(fmt.Sprintf(" fin"))
+	}
+
+	optLen -= 4
+
+	if mdss.Flags&MP_DSS_A != 0 {
+		// Ack present
+		buf.WriteString(fmt.Sprintf(" ack "))
+
+		// If the 'a' flag is set, we have an 8-byte ack; if it's clear, we have a 4-byte ack.
+		if mdss.Flags&MP_DSS_a != 0 {
+			if optLen < 8 {
+				return fmt.Errorf("invalid length for dss ack: %d", optLen)
+			}
+			ack := binary.BigEndian.Uint64(opt.OptionMPTCPDss.DataAck)
+			buf.WriteString(fmt.Sprintf("%d", ack))
+			optLen -= 8
+		} else {
+			if optLen < 4 {
+				return fmt.Errorf("invalid length for dss ack: %d", optLen)
+			}
+			var ack uint64
+			switch len(opt.OptionMPTCPDss.DataAck) {
+			case 8:
+				ack = binary.BigEndian.Uint64(opt.OptionMPTCPDss.DataAck)
+			case 4:
+				ack = uint64(binary.BigEndian.Uint32(opt.OptionMPTCPDss.DataAck))
+			}
+			buf.WriteString(fmt.Sprintf("%d", ack))
+			optLen -= 4
+		}
+	}
+
+	if mdss.Flags&MP_DSS_M != 0 {
+		// Data Sequence Number (DSN), Subflow Sequence Number (SSN), Data-Level Length present, and Checksum possibly present.
+		buf.WriteString(fmt.Sprintf(" seq "))
+
+		// If the 'm' flag is set, we have an 8-byte NDS; if it's clear, we have a 4-byte DSN.
+		if mdss.Flags&MP_DSS_m != 0 {
+			if optLen < 8 {
+				return fmt.Errorf("invalid length for dss seq: %d", optLen)
+			}
+			var seq uint64
+			switch len(opt.OptionMPTCPDss.DataAck) {
+			case 8:
+				seq = binary.BigEndian.Uint64(opt.OptionMPTCPDss.DSN)
+			case 4:
+				seq = uint64(binary.BigEndian.Uint32(opt.OptionMPTCPDss.DSN))
+			}
+			buf.WriteString(fmt.Sprintf("%d", seq))
+			optLen -= 8
+		} else {
+			if optLen < 4 {
+				return fmt.Errorf("invalid length for dss seq: %d", optLen)
+			}
+			seq := binary.BigEndian.Uint64(opt.OptionMPTCPDss.DSN)
+			buf.WriteString(fmt.Sprintf("%d", seq))
+			optLen -= 4
+		}
+
+		if optLen < 4 {
+			return fmt.Errorf("invalid length for dss subseq: %d", optLen)
+		}
+		subSeq := opt.OptionMPTCPDss.SSN
+		buf.WriteString(fmt.Sprintf(" subseq %d", subSeq))
+		optLen -= 4
+
+		if optLen < 2 {
+			return fmt.Errorf("invalid length for dss len: %d", optLen)
+		}
+		var length = opt.OptionMPTCPDss.DataLength
+		buf.WriteString(fmt.Sprintf(" len %d", length))
+		optLen -= 2
+
+		// The Checksum is present only if negotiated.
+		// If there are at least 2 bytes left, process the next 2 bytes as the Checksum.
+		if optLen >= 2 {
+			var csum uint16 = opt.OptionMPTCPDss.Checksum
+			buf.WriteString(fmt.Sprintf(" csum 0x%x", csum))
+			optLen -= 2
+		}
+	}
+
+	if optLen != 0 {
+		return fmt.Errorf("invalid length for dss option: %d", optLen)
+	}
+
+	return nil
+}
+
+// addAddrPrint prints the "add-addr" option.
+func addAddrPrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *strings.Builder) error {
+	addAddr := MPAddAddr{}
+	addAddr.Kind = uint8(opt.OptionType)
+	addAddr.Len = opt.OptionLength
+	addAddr.SubEcho = opt.OptionMPTCPAddAddr.SubEcho
+	addAddr.AddrID = opt.OptionMPTCPAddAddr.SubEcho
+	optLen := opt.OptionLength
+
+	if !(optLen == 8 || optLen == 10 || optLen == 16 || optLen == 18 || optLen == 20 || optLen == 22 || optLen == 28 || optLen == 30) {
+		return fmt.Errorf("invalid length for add-addr option: %d", optLen)
+	}
+
+	subEchoStr := tok2str(MPTCPAddrSubEchoBits, "[bad version/echo]", uint32(addAddr.SubEcho&0xF))
+	buf.WriteString(fmt.Sprintf(" %s", subEchoStr))
+	buf.WriteString(fmt.Sprintf(" id %d", addAddr.AddrID))
+
+	if optLen == 8 || optLen == 10 || optLen == 16 || optLen == 18 {
+		addAddr.U.V4.Addr = binary.BigEndian.Uint32(opt.OptionMPTCPAddAddr.Address)
+		if optLen == 10 || optLen == 18 {
+			addAddr.U.V4.Port = opt.OptionMPTCPAddAddr.Port
+		}
+		if optLen == 16 {
+			addAddr.U.V4NP.Mac = binary.BigEndian.Uint64(opt.OptionMPTCPAddAddr.SendHMAC)
+		}
+		if optLen == 18 {
+			addAddr.U.V4NP.Mac = binary.BigEndian.Uint64(opt.OptionMPTCPAddAddr.SendHMAC)
+		}
+
+		buf.WriteString(fmt.Sprintf(" %d", addAddr.U.V4.Addr))
+		if optLen == 10 || optLen == 18 {
+			buf.WriteString(fmt.Sprintf(":%d", addAddr.U.V4.Port))
+		}
+		if optLen == 16 {
+			buf.WriteString(fmt.Sprintf(" hmac 0x%x", addAddr.U.V4NP.Mac))
+		}
+		if optLen == 18 {
+			buf.WriteString(fmt.Sprintf(" hmac 0x%x", addAddr.U.V4.Mac))
+		}
+	}
+
+	if optLen == 20 || optLen == 22 || optLen == 28 || optLen == 30 {
+		copy(addAddr.U.V6.Addr[:], opt.OptionMPTCPAddAddr.Address)
+		if optLen == 22 || optLen == 30 {
+			addAddr.U.V6.Port = opt.OptionMPTCPAddAddr.Port
+		}
+		if optLen == 28 {
+			addAddr.U.V6NP.Mac = binary.BigEndian.Uint64(opt.OptionMPTCPAddAddr.SendHMAC)
+		}
+		if optLen == 30 {
+			addAddr.U.V6NP.Mac = binary.BigEndian.Uint64(opt.OptionMPTCPAddAddr.SendHMAC)
+		}
+
+		buf.WriteString(fmt.Sprintf(" %v", addAddr.U.V6.Addr))
+		if optLen == 22 || optLen == 30 {
+			buf.WriteString(fmt.Sprintf(":%d", addAddr.U.V6.Port))
+		}
+		if optLen == 28 {
+			buf.WriteString(fmt.Sprintf(" hmac 0x%x", addAddr.U.V6NP.Mac))
+		}
+		if optLen == 30 {
+			buf.WriteString(fmt.Sprintf(" hmac 0x%x", addAddr.U.V6.Mac))
+		}
+	}
+
+	return nil
+}
+
+// removeAddrPrint prints the "rem-addr" option.
+func removeAddrPrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *strings.Builder) error {
+	removeAddr := MPRemoveAddr{}
+	removeAddr.Kind = uint8(opt.OptionType)
+	removeAddr.Len = opt.OptionLength
+	removeAddr.Sub = opt.OptionMTCPRemAddr.Sub
+	optLen := int(opt.OptionLength)
+
+	if optLen < 4 {
+		return fmt.Errorf("invalid length for rem-addr option: %d", optLen)
+	}
+
+	optLen -= 3
+	removeAddr.AddrsID = make([]uint8, optLen)
+	removeAddr.AddrsID = opt.OptionMTCPRemAddr.AddrIDs
+
+	buf.WriteString(fmt.Sprintf(" id"))
+	for i := 0; i < optLen; i++ {
+		buf.WriteString(fmt.Sprintf(" %d", removeAddr.AddrsID[i]))
+	}
+	return nil
+}
+
+// mpPrioPrint prints the "prio" option.
+func mpPrioPrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *strings.Builder) error {
+	mpPrio := MPPrio{}
+	mpPrio.Kind = uint8(opt.OptionType)
+	mpPrio.Len = opt.OptionLength
+	mpPrio.SubB = opt.OptionMPTCPMpPrio.SubB
+	optLen := opt.OptionLength
+
+	if optLen != 3 && optLen != 4 {
+		return fmt.Errorf("invalid length for prio option: %d", optLen)
+	}
+
+	if mpPrio.SubB&MP_PRIO_B != 0 {
+		buf.WriteString(fmt.Sprintf(" backup"))
+	} else {
+		buf.WriteString(fmt.Sprintf(" non-backup"))
+	}
+
+	if optLen == 4 {
+		mpPrio.AddrID = opt.OptionMPTCPMpPrio.AddrID
+		buf.WriteString(fmt.Sprintf(" id %d", mpPrio.AddrID))
+	}
+
+	return nil
+}
+
+// mpFailPrint prints the "fail" option.
+func mpFailPrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *strings.Builder) error {
+	optLen := opt.OptionLength
+	if optLen != 12 {
+		return fmt.Errorf("invalid length for fail option: %d", optLen)
+	}
+	var dataSeq uint64 = opt.OptionMTCPMPFail.DSN
+	buf.WriteString(fmt.Sprintf(" seq %d", dataSeq))
+
+	return nil
+}
+
+// mpFastClosePrint prints the "fast-close" option.
+func mpFastClosePrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *strings.Builder) error {
+	optLen := opt.OptionLength
+	if optLen != 12 {
+		return fmt.Errorf("invalid length for fast-close option: %d", optLen)
+	}
+	var key = binary.BigEndian.Uint64(opt.OptionMTCPMPFastClose.ReceivKey)
+	buf.WriteString(fmt.Sprintf(" key 0x%x", key))
+
+	return nil
+}
+
+// mpTCPRSTPrint prints the "tcprst" option.
+func mpTCPRSTPrint(options *mptcpPrintOptions, opt layers.TCPOption, buf *strings.Builder) error {
+	mpr := MPTCPRST{}
+	mpr.Kind = uint8(opt.OptionType)
+	mpr.Len = opt.OptionLength
+	mpr.SubB = opt.OptionMPTCPMPTcpRst.SubB
+	mpr.Reason = opt.OptionMPTCPMPTcpRst.Reason
+	optLen := opt.OptionLength
+
+	if optLen != 4 {
+		return fmt.Errorf("invalid length for tcprst option: %d", optLen)
+	}
+
+	flagsStr := bittok2str(MPTCPFlags, "none", uint32(mpr.SubB))
+	buf.WriteString(fmt.Sprintf(" flags [%s]", flagsStr))
+
+	reasonStr := tok2str(MPTCPRSTReasons, "unknown (0x%02x)", uint32(mpr.Reason))
+	buf.WriteString(fmt.Sprintf(" reason %s", reasonStr))
+
+	return nil
+}
+
+// mptcpPrintOptions represents the options for MPTCP printing.
+type mptcpPrintOptions struct {
+	// TODO: Add any relevant options here.
+}
+
+// MPTCPPrintOptions defines the print functions for each MPTCP option.
+var MPTCPPrintOptions = []struct {
+	Name  string
+	Print func(*mptcpPrintOptions, layers.TCPOption, *strings.Builder) error
+}{
+	{"capable", mpCapablePrint},
+	{"join", mpJoinPrint},
+	{"dss", mpDSSPrint},
+	{"add-addr", addAddrPrint},
+	{"rem-addr", removeAddrPrint},
+	{"prio", mpPrioPrint},
+	{"fail", mpFailPrint},
+	{"fast-close", mpFastClosePrint},
+	{"tcprst", mpTCPRSTPrint},
+	{"unknown", dummyPrint},
+}
+
+// mptcpPrint prints an MPTCP option.
+func mptcpPrint(options *mptcpPrintOptions, opt layers.TCPOption) (string, error) {
+	buf := strings.Builder{}
+	// Ensure the length is valid.
+	length := opt.OptionLength
+	if length < 3 {
+		return "", fmt.Errorf("invalid length for MPTCP option: %d", length)
+	}
+	buf.WriteString("mptcp")
+
+	// Parse the MPTCP option.
+	//mptcpOpt := MPTCPOption{
+	//	Kind:   0,
+	//	Len:    opt.OptionLength,
+	//	SubEtc: uint8(opt.OptionMultipath),
+	//}
+
+	// Determine the subtype.
+	subtype := MPTCPSub(opt.OptionMultipath)
+	if subtype > MPTCPSubTCPRST {
+		subtype = MPTCPSubTCPRST + 1
+	}
+
+	// Print the option details.
+	buf.WriteString(fmt.Sprintf(" %d", length))
+	buf.WriteString(fmt.Sprintf(" %s", MPTCPPrintOptions[subtype].Name))
+
+	// Call the corresponding print function for the subtype.
+	err := MPTCPPrintOptions[subtype].Print(options, opt, &buf)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// bittok2str converts a set of flags to a string representation.
+func bittok2str(tokens []Token, defaultStr string, value uint32) string {
+	var strs []string
+	for _, token := range tokens {
+		if value&token.Value != 0 {
+			strs = append(strs, token.Str)
+		}
+	}
+	if len(strs) == 0 {
+		return defaultStr
+	}
+	return fmt.Sprintf("%s", strings.Join(strs, " "))
+}
+
+func formatMPTCP(opt layers.TCPOption) string {
+	s, _ := mptcpPrint(&mptcpPrintOptions{}, opt)
+	return s
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/google/uuid v1.6.0
 ## explicit
 github.com/google/uuid
-# github.com/gopacket/gopacket v1.2.0 => github.com/mozillazg/gopacket v0.0.0-20240602032747-2b08f0c63614
+# github.com/gopacket/gopacket v1.2.0 => github.com/mozillazg/gopacket v0.0.0-20240928025743-af4d18b65a70
 ## explicit; go 1.20
 github.com/gopacket/gopacket
 github.com/gopacket/gopacket/layers
@@ -320,7 +320,7 @@ github.com/tklauser/go-sysconf
 # github.com/tklauser/numcpus v0.6.1
 ## explicit; go 1.13
 github.com/tklauser/numcpus
-# github.com/x-way/pktdump v0.0.5 => github.com/mozillazg/pktdump v0.0.9-0.20240926140652-120bcf8d8890
+# github.com/x-way/pktdump v0.0.5 => github.com/mozillazg/pktdump v0.0.9-0.20240928035206-3598f58e5bfd
 ## explicit; go 1.19
 github.com/x-way/pktdump
 # github.com/yusufpapurcu/wmi v1.2.4
@@ -510,8 +510,8 @@ rsc.io/binaryregexp/syntax
 # github.com/Microsoft/hcsshim/test => github.com/Microsoft/hcsshim/test v0.0.0-20210514012740-eba372547321
 # github.com/containerd/containerd => github.com/containerd/containerd v1.4.13
 # github.com/docker/docker => github.com/docker/docker v24.0.9+incompatible
-# github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240602032747-2b08f0c63614
-# github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240926140652-120bcf8d8890
+# github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240928025743-af4d18b65a70
+# github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240928035206-3598f58e5bfd
 # go.opencensus.io => go.opencensus.io v0.23.0
 # go.opentelemetry.io/contrib => go.opentelemetry.io/contrib v0.20.0
 # go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/google/uuid v1.6.0
 ## explicit
 github.com/google/uuid
-# github.com/gopacket/gopacket v1.2.0 => github.com/mozillazg/gopacket v0.0.0-20240929131848-5b85f4bf5509
+# github.com/gopacket/gopacket v1.2.0 => github.com/mozillazg/gopacket v0.0.0-20240930124105-2e5a32c1b751
 ## explicit; go 1.20
 github.com/gopacket/gopacket
 github.com/gopacket/gopacket/layers
@@ -320,7 +320,7 @@ github.com/tklauser/go-sysconf
 # github.com/tklauser/numcpus v0.6.1
 ## explicit; go 1.13
 github.com/tklauser/numcpus
-# github.com/x-way/pktdump v0.0.5 => github.com/mozillazg/pktdump v0.0.9-0.20240930075705-eef9ebfadc19
+# github.com/x-way/pktdump v0.0.5 => github.com/mozillazg/pktdump v0.0.9-0.20240930140149-682051b53f64
 ## explicit; go 1.19
 github.com/x-way/pktdump
 # github.com/yusufpapurcu/wmi v1.2.4
@@ -510,8 +510,8 @@ rsc.io/binaryregexp/syntax
 # github.com/Microsoft/hcsshim/test => github.com/Microsoft/hcsshim/test v0.0.0-20210514012740-eba372547321
 # github.com/containerd/containerd => github.com/containerd/containerd v1.4.13
 # github.com/docker/docker => github.com/docker/docker v24.0.9+incompatible
-# github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240929131848-5b85f4bf5509
-# github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240930075705-eef9ebfadc19
+# github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240930124105-2e5a32c1b751
+# github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240930140149-682051b53f64
 # go.opencensus.io => go.opencensus.io v0.23.0
 # go.opentelemetry.io/contrib => go.opentelemetry.io/contrib v0.20.0
 # go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/google/uuid v1.6.0
 ## explicit
 github.com/google/uuid
-# github.com/gopacket/gopacket v1.2.0 => github.com/mozillazg/gopacket v0.0.0-20240930124105-2e5a32c1b751
+# github.com/gopacket/gopacket v1.2.0 => github.com/mozillazg/gopacket v0.0.0-20241002124513-c32042430295
 ## explicit; go 1.20
 github.com/gopacket/gopacket
 github.com/gopacket/gopacket/layers
@@ -320,7 +320,7 @@ github.com/tklauser/go-sysconf
 # github.com/tklauser/numcpus v0.6.1
 ## explicit; go 1.13
 github.com/tklauser/numcpus
-# github.com/x-way/pktdump v0.0.5 => github.com/mozillazg/pktdump v0.0.9-0.20240930140149-682051b53f64
+# github.com/x-way/pktdump v0.0.5 => github.com/mozillazg/pktdump v0.0.9-0.20241002124615-e03da3440378
 ## explicit; go 1.19
 github.com/x-way/pktdump
 # github.com/yusufpapurcu/wmi v1.2.4
@@ -510,8 +510,8 @@ rsc.io/binaryregexp/syntax
 # github.com/Microsoft/hcsshim/test => github.com/Microsoft/hcsshim/test v0.0.0-20210514012740-eba372547321
 # github.com/containerd/containerd => github.com/containerd/containerd v1.4.13
 # github.com/docker/docker => github.com/docker/docker v24.0.9+incompatible
-# github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240930124105-2e5a32c1b751
-# github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240930140149-682051b53f64
+# github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20241002124513-c32042430295
+# github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20241002124615-e03da3440378
 # go.opencensus.io => go.opencensus.io v0.23.0
 # go.opentelemetry.io/contrib => go.opentelemetry.io/contrib v0.20.0
 # go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/google/uuid v1.6.0
 ## explicit
 github.com/google/uuid
-# github.com/gopacket/gopacket v1.2.0 => github.com/mozillazg/gopacket v0.0.0-20240928025743-af4d18b65a70
+# github.com/gopacket/gopacket v1.2.0 => github.com/mozillazg/gopacket v0.0.0-20240929131848-5b85f4bf5509
 ## explicit; go 1.20
 github.com/gopacket/gopacket
 github.com/gopacket/gopacket/layers
@@ -320,7 +320,7 @@ github.com/tklauser/go-sysconf
 # github.com/tklauser/numcpus v0.6.1
 ## explicit; go 1.13
 github.com/tklauser/numcpus
-# github.com/x-way/pktdump v0.0.5 => github.com/mozillazg/pktdump v0.0.9-0.20240928035206-3598f58e5bfd
+# github.com/x-way/pktdump v0.0.5 => github.com/mozillazg/pktdump v0.0.9-0.20240930075705-eef9ebfadc19
 ## explicit; go 1.19
 github.com/x-way/pktdump
 # github.com/yusufpapurcu/wmi v1.2.4
@@ -510,8 +510,8 @@ rsc.io/binaryregexp/syntax
 # github.com/Microsoft/hcsshim/test => github.com/Microsoft/hcsshim/test v0.0.0-20210514012740-eba372547321
 # github.com/containerd/containerd => github.com/containerd/containerd v1.4.13
 # github.com/docker/docker => github.com/docker/docker v24.0.9+incompatible
-# github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240928025743-af4d18b65a70
-# github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240928035206-3598f58e5bfd
+# github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20240929131848-5b85f4bf5509
+# github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20240930075705-eef9ebfadc19
 # go.opencensus.io => go.opencensus.io v0.23.0
 # go.opentelemetry.io/contrib => go.opentelemetry.io/contrib v0.20.0
 # go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/google/uuid v1.6.0
 ## explicit
 github.com/google/uuid
-# github.com/gopacket/gopacket v1.2.0 => github.com/mozillazg/gopacket v0.0.0-20241002124513-c32042430295
+# github.com/gopacket/gopacket v1.2.0 => github.com/mozillazg/gopacket v0.0.0-20241002125412-112c3fb39360
 ## explicit; go 1.20
 github.com/gopacket/gopacket
 github.com/gopacket/gopacket/layers
@@ -510,7 +510,7 @@ rsc.io/binaryregexp/syntax
 # github.com/Microsoft/hcsshim/test => github.com/Microsoft/hcsshim/test v0.0.0-20210514012740-eba372547321
 # github.com/containerd/containerd => github.com/containerd/containerd v1.4.13
 # github.com/docker/docker => github.com/docker/docker v24.0.9+incompatible
-# github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20241002124513-c32042430295
+# github.com/gopacket/gopacket => github.com/mozillazg/gopacket v0.0.0-20241002125412-112c3fb39360
 # github.com/x-way/pktdump => github.com/mozillazg/pktdump v0.0.9-0.20241002124615-e03da3440378
 # go.opencensus.io => go.opencensus.io v0.23.0
 # go.opentelemetry.io/contrib => go.opentelemetry.io/contrib v0.20.0


### PR DESCRIPTION
Closes #148 

```
02:55:35.698856 IP (...).34204 > (...).12345: Flags [S], seq 412382786, win 65495, options [mss 65495,sackOK,TS val 642407978 ecr 0,nop,wscale 7,mptcp 4 capable v1 flags [H]], length 0
02:55:35.698936 IP (...).12345 > (...).34204: Flags [S.], seq 2707981557, ack 412382787, win 65483, options [mss 65495,sackOK,TS val 642407978 ecr 642407978,nop,wscale 7,mptcp 12 capable v1 flags [H] {0xe356a8f252e41976}], length 0
02:55:35.699025 IP (...).34204 > (...).12345: Flags [.], seq 412382787, ack 2707981558, win 512, options [nop,nop,TS val 642407978 ecr 642407978,mptcp 20 capable v1 flags [H] {0xfe7b93dc894dcb73,0xe356a8f252e41976}], length 0
02:55:38.509583 IP (...).34204 > (...).12345: Flags [P.], seq 412382787:412382792, ack 2707981558, win 512, options [nop,nop,TS val 642410789 ecr 642407978,mptcp 22 capable v1 flags [H] {0xfe7b93dc894dcb73,0xe356a8f252e41976,data_len=5},nop,nop], length 5
```