### PR TITLE
fix(capture/subprogram): Fix capture by process via run target program

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -53,6 +53,7 @@ func capture(ctx context.Context, stopFunc context.CancelFunc, opts *Options) er
 
 	log.Info("start get current connections")
 	conns := getCurrentConnects(ctx, pcache, opts)
+	log.Infof("got %d connections", len(conns))
 
 	copts := opts.ToCapturerOptions()
 	copts.Connections = conns
@@ -154,6 +155,10 @@ func getCaptureCounts(bf *bpf.BPF, c *consumer.PacketEventConsumer) []string {
 func getCurrentConnects(ctx context.Context, pcache *metadata.ProcessCache, opts *Options) []metadata.Connection {
 	var pids []int
 	var filterPid bool
+
+	if len(opts.subProgArgs) > 0 {
+		return nil
+	}
 
 	if len(opts.pids) > 0 {
 		filterPid = true

--- a/internal/capturer/capturer.go
+++ b/internal/capturer/capturer.go
@@ -124,6 +124,7 @@ func (c *Capturer) StartSubProcessLoader(ctx context.Context, program string, su
 	if err != nil {
 		return err
 	}
+	log.Infof("will filter by pid: %d", c.subProcessLoaderPid)
 	c.opts.Pids = []uint{uint(c.subProcessLoaderPid)}
 	c.opts.FollowForks = true
 

--- a/internal/utils/exec.go
+++ b/internal/utils/exec.go
@@ -57,6 +57,7 @@ func StartSubProcess(ctx context.Context, Args []string) error {
 	if err := cmd.Start(); err != nil {
 		return err
 	}
+	log.Infof("started sub program, his pid is %d", cmd.Process.Pid)
 
 	if err := cmd.Wait(); err != nil {
 		return err

--- a/testdata/test_sub_curl_domain_program.sh
+++ b/testdata/test_sub_curl_domain_program.sh
@@ -10,7 +10,7 @@ RNAME="${FILE_PREFIX}_sub_program_curl.read.txt"
 
 
 function test_ptcpdump() {
-  timeout 30s ${CMD} -i any -v --print -w "${FNAME}"  \
+  timeout 30s ${CMD} -c 10 -i any -v --print -w "${FNAME}"  \
 	  -- curl -m 10 ubuntu.com | tee "${LNAME}"
 
   cat "${LNAME}"

--- a/testdata/test_sub_curl_domain_program.sh
+++ b/testdata/test_sub_curl_domain_program.sh
@@ -10,7 +10,7 @@ RNAME="${FILE_PREFIX}_sub_program_curl.read.txt"
 
 
 function test_ptcpdump() {
-  timeout 30s ${CMD} -c 10 -i any -v --print -w "${FNAME}"  \
+  timeout 30s ${CMD} -i any -v --print -w "${FNAME}"  \
 	  -- curl -m 10 ubuntu.com | tee "${LNAME}"
 
   cat "${LNAME}"

--- a/testdata/test_sub_program.sh
+++ b/testdata/test_sub_program.sh
@@ -10,7 +10,7 @@ RNAME="${FILE_PREFIX}_sub_program.read.txt"
 
 
 function test_ptcpdump() {
-  timeout 30s ${CMD} -i any -v --print -w "${FNAME}" \
+  timeout 30s ${CMD} -c 10 -i any -v --print -w "${FNAME}" \
 	  -- curl -m 10 1.1.1.1 | tee "${LNAME}"
 
   cat "${LNAME}"


### PR DESCRIPTION
This PR fixes a bug that prevented the capture by process via run target program feature from working correctly.

The bug was introduced in PR #162.