### PR TITLE
feat: support filter by container-id prefix matching 12 or more characters

### DIFF
--- a/internal/metadata/container/containerd/containerd.go
+++ b/internal/metadata/container/containerd/containerd.go
@@ -126,7 +126,7 @@ func (d *MetaData) GetById(containerId string) types.Container {
 	id := getContainerId(containerId)
 	log.Debugf("get by id, id: %s", id)
 
-	if len(id) == shortContainerIdLength {
+	if len(id) >= shortContainerIdLength {
 		return d.getByShortId(id)
 	}
 

--- a/internal/metadata/container/docker/docker.go
+++ b/internal/metadata/container/docker/docker.go
@@ -80,7 +80,7 @@ func (d *MetaData) GetById(containerId string) types.Container {
 
 	id := getDockerContainerId(containerId)
 
-	if len(id) == shortContainerIdLength {
+	if len(id) >= shortContainerIdLength {
 		return d.getByShortId(id)
 	}
 


### PR DESCRIPTION
Modify the condition to allow more than 12 characters prefix matching

close: #217 