### PR TITLE
fix(cli): Correct handling of `-s 0` for snapshot length

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Filter like tcpdump:
 ```
 sudo ptcpdump -i eth0 tcp
 sudo ptcpdump -i eth0 -A -s 0 -n -v tcp and port 80 and host 10.10.1.1
-sudo ptcpdump -i any -s 0 -n -v -C 100MB -W 3 'tcp and port 80 and host 10.10.1.1'
+sudo ptcpdump -i any -s 0 -n -v -C 100MB -W 3 -w test.pcapng 'tcp and port 80 and host 10.10.1.1'
 sudo ptcpdump -i eth0 'tcp[tcpflags] & (tcp-syn|tcp-fin) != 0'
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,7 +75,7 @@ Table of Contents
 ```
 sudo ptcpdump -i eth0 tcp
 sudo ptcpdump -i eth0 -A -s 0 -n -v tcp and port 80 and host 10.10.1.1
-sudo ptcpdump -i any -s 0 -n -v -C 100MB -W 3 'tcp and port 80 and host 10.10.1.1'
+sudo ptcpdump -i any -s 0 -n -v -C 100MB -W 3 -w test.pcapng 'tcp and port 80 and host 10.10.1.1'
 sudo ptcpdump -i eth0 'tcp[tcpflags] & (tcp-syn|tcp-fin) != 0'
 ```
 

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -31,6 +31,8 @@ const (
 	contextPod        = "pod"
 )
 
+const defaultSnapShotLength uint32 = 262144
+
 type Options struct {
 	ifaces         []string
 	pids           []uint
@@ -154,6 +156,9 @@ func prepareOptions(opts *Options, rawArgs []string, args []string) error {
 	opts.timestampN = opts.printTimestamp
 	if opts.printTimestamp == 1 {
 		opts.dontPrintTimestamp = true
+	}
+	if opts.snapshotLength <= 0 {
+		opts.snapshotLength = defaultSnapShotLength
 	}
 
 	if opts.dockerEndpoint != "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,7 +100,7 @@ func init() {
 		"Address of CRI container runtime service "+
 			fmt.Sprintf("(default: uses in order the first successful one of [%s])",
 				strings.Join(getDefaultCriRuntimeEndpoint(), ", ")))
-	rootCmd.Flags().Uint32VarP(&opts.snapshotLength, "snapshot-length", "s", 262144,
+	rootCmd.Flags().Uint32VarP(&opts.snapshotLength, "snapshot-length", "s", defaultSnapShotLength,
 		"Snarf snaplen bytes of data from each packet rather than the default of 262144 bytes")
 	rootCmd.Flags().StringVar(&opts.btfPath, "kernel-btf", "",
 		fmt.Sprintf("specify kernel BTF file (default: uses in order the first successful one of [%s]",

--- a/testdata/test_base.sh
+++ b/testdata/test_base.sh
@@ -10,7 +10,7 @@ RNAME="${FILE_PREFIX}_base.read.txt"
 
 
 function test_ptcpdump() {
-  timeout 30s ${CMD} -c 1 -v -i any ${PTCPDUMP_EXTRA_ARGS} --print -w "${FNAME}"  \
+  timeout 30s ${CMD} -c 1 -s 0 -nnn -v -i any ${PTCPDUMP_EXTRA_ARGS} --print -w "${FNAME}"  \
     'dst host 1.1.1.1 and tcp[tcpflags] = tcp-syn' | tee "${LNAME}" &
   sleep 10
   curl -m 10 1.1.1.1 &>/dev/null || true


### PR DESCRIPTION
This commit resolves a bug where the` -s 0` option was not handled correctly. Previously, using `-s 0` resulted in a crash.