### PR TITLE
fix: revert GetBootTimeNs() to fix timestamp drift

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -84,23 +84,12 @@ func GetKernelVersion() (string, error) {
 	return kernelVersionInfo.version, kernelVersionInfo.err
 }
 
-var bootTimeInfo struct {
-	once sync.Once
-	ts   int64
-	err  error
-}
-
 func GetBootTimeNs() (int64, error) {
-	bootTimeInfo.once.Do(func() {
-		var ts unix.Timespec
-		err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
-		if err != nil {
-			bootTimeInfo.err = fmt.Errorf("could not get time: %w", err)
-		} else {
+	var ts unix.Timespec
+	err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
+	if err != nil {
+		return 0, fmt.Errorf("could not get time: %w", err)
+	}
 
-			bootTimeInfo.ts = unix.TimespecToNsec(ts)
-		}
-	})
-
-	return bootTimeInfo.ts, bootTimeInfo.err
+	return unix.TimespecToNsec(ts), nil
 }


### PR DESCRIPTION
Hello,

It seems that there is a timestamp drift for each captured packet : after the first capture, every real second elapsed would be like 2 seconds in the timestamp.

I discovered this when running `ptcpdump` against a `ping` command : timestamps would be 2 seconds apart instead of 1.
```sh
# In a first terminal: ping every second (and mark the time of the first ping with date command)
$ date ; ping github.com
Sat Apr 13 10:29:54 CEST 2025
PING github.com (140.82.121.3) 56(84) bytes of data.
64 bytes from lb-140-82-121-3-fra.github.com (140.82.121.3): icmp_seq=1 ttl=51 time=68.1 ms
64 bytes from lb-140-82-121-3-fra.github.com (140.82.121.3): icmp_seq=2 ttl=51 time=64.9 ms
64 bytes from lb-140-82-121-3-fra.github.com (140.82.121.3): icmp_seq=3 ttl=51 time=88.2 ms

# In a second terminal: packets have timestamps with 2 seconds apart (instead of the expected 1 second)
$ sudo ./ptcpdump -i any | grep "ICMP echo request"
2025-04-13 10:29:43 WARN ptcpdump: verbose output suppressed, use -v[v]... for verbose output
2025-04-13 10:29:43 WARN capturing on any, link-type EN10MB (Ethernet), snapshot length 262144 bytes, backend tc
10:29:54.071422 wlp2s0 ping.10930 Out IP 192.168.137.43 > 140.82.121.3: ICMP echo request, id 10930, seq 1, length 64, ParentProc [bash.10306]
10:29:56.074384 wlp2s0 ping.10930 Out IP 192.168.137.43 > 140.82.121.3: ICMP echo request, id 10930, seq 2, length 64, ParentProc [bash.10306]
10:29:58.077834 wlp2s0 ping.10930 Out IP 192.168.137.43 > 140.82.121.3: ICMP echo request, id 10930, seq 3, length 64, ParentProc [bash.10306]
```


After some analysis, the timestamp drift appeared with the version `v0.16.0`, and was precisely added by the commit bcd9064.
And with further investigation, the drift comes from a change in the `GetBootTimeNs()` function (renamed from `getBootTimeNs()` before the commit cause it was moved into another file). 

`GetBootTimeNs()` returns _monotonic clock time_ to compare with the _monotonic clock time_ in the packet's metadata, in order to compute the timestamp when the packet was captured in current time, as done in [`convertBpfKTimeNs()`](https://github.com/mozillazg/ptcpdump/blob/v0.33.1/internal/event/net.go#L140) :
```go
func convertBpfKTimeNs(t uint64) (time.Time, error) {
	b, err := host.GetBootTimeNs()
	if err != nil {
		return time.Time{}, err
	}

	return time.Now().Add(-time.Duration(b - int64(t))), nil
}
```
In commit bcd9064, `GetBootTimeNs()` logic was changed to only get the _monotonic clock time_ once with the first capture, and reuse the value for the next packets (with `sync.Once()`, probably to avoid asking the system the clock for each packet).
However, to correctly compute the timestamp, `GetBootTimeNs()` and `time.Now()` should correspond to the same time on different references ; but with this change, they are no more equivalent : `GetBootTimeNs()` is fixed whereas `time.Now()` is increasing.
This explains the timestamp drift : as `GetBootTimeNs()` is constant after the first capture, computing the difference between `GetBootTimeNs()` and the packet's clock no more gives a delta time to deduce the current time when the packet was captured, instead it gives the delta time from the first capture which is then added to `time.Now()`.

The suggested fix is simply to revert the `GetBootTimeNs()` function to a previous version before `sync.Once()` was added.