### PR TITLE
feat(output): Include network namespace inode ID in interface name for cross-namespace interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,16 +381,16 @@ If this flag isn't specified, it defaults to `tc`.
 
         $ sudo ptcpdump -i any --backend cgroup-skb host 1.1.1.1
 
-        12:20:31.336108 dummy-45 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, Thread [curl.405939], ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.467819 dummy-45 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [S.], seq 488132001, ack 3064539220, win 64240, options [mss 1460], length 0, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.467876 dummy-45 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539220, ack 488132002, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.468072 dummy-45 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [P.], seq 3064539220:3064539291, ack 488132002, win 64240, length 71, Thread [curl.405939], ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.468681 dummy-45 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132002, ack 3064539291, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.575750 dummy-45 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [P.], seq 488132002:488132388, ack 3064539291, win 64240, length 386, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.575848 dummy-45 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539291, ack 488132388, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.576982 dummy-45 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [F.], seq 3064539291, ack 488132388, win 63854, length 0, Thread [curl.405939], ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.577843 dummy-45 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132388, ack 3064539292, win 64239, length 0, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.687357 dummy-45 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539292, ack 488132389, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.336108 45@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, Thread [curl.405939], ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.467819 45@4026533097 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [S.], seq 488132001, ack 3064539220, win 64240, options [mss 1460], length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.467876 45@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539220, ack 488132002, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.468072 45@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [P.], seq 3064539220:3064539291, ack 488132002, win 64240, length 71, Thread [curl.405939], ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.468681 45@4026533097 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132002, ack 3064539291, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.575750 45@4026533097 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [P.], seq 488132002:488132388, ack 3064539291, win 64240, length 386, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.575848 45@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539291, ack 488132388, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.576982 45@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [F.], seq 3064539291, ack 488132388, win 63854, length 0, Thread [curl.405939], ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.577843 45@4026533097 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132388, ack 3064539292, win 64239, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.687357 45@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539292, ack 488132389, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
 
 
   * `--backend socket-filter`:
@@ -429,47 +429,47 @@ If this flag isn't specified, it defaults to `tc`.
 
         $ sudo ptcpdump -i any --backend tp-btf host 1.1.1.1
 
-        12:20:31.336316 eth0 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.336316 eth0@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.336382 veth1d387b0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.336443 docker0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.336801 ens33 Out IP 10.0.2.15.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0
         12:20:31.467682 ens33 In IP 1.1.1.1.80 > 10.0.2.15.38670: Flags [S.], seq 488132001, ack 3064539220, win 64240, options [mss 1460], length 0
         12:20:31.467773 docker0 curl.405939 Out IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [S.], seq 488132001, ack 3064539220, win 64240, options [mss 1460], length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.467783 veth1d387b0 curl.405939 Out IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [S.], seq 488132001, ack 3064539220, win 64240, options [mss 1460], length 0, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.467811 eth0 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [S.], seq 488132001, ack 3064539220, win 64240, options [mss 1460], length 0, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.468005 eth0 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539220, ack 488132002, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.467811 eth0@4026533097 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [S.], seq 488132001, ack 3064539220, win 64240, options [mss 1460], length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.468005 eth0@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539220, ack 488132002, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.468022 veth1d387b0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539220, ack 488132002, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.468029 docker0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539220, ack 488132002, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.468063 ens33 Out IP 10.0.2.15.38670 > 1.1.1.1.80: Flags [.], seq 3064539220, ack 488132002, win 64240, length 0
-        12:20:31.468078 eth0 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [P.], seq 3064539220:3064539291, ack 488132002, win 64240, length 71, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.468078 eth0@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [P.], seq 3064539220:3064539291, ack 488132002, win 64240, length 71, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.468085 veth1d387b0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [P.], seq 3064539220:3064539291, ack 488132002, win 64240, length 71, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.468091 docker0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [P.], seq 3064539220:3064539291, ack 488132002, win 64240, length 71, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.468112 ens33 Out IP 10.0.2.15.38670 > 1.1.1.1.80: Flags [P.], seq 3064539220:3064539291, ack 488132002, win 64240, length 71
         12:20:31.468446 ens33 In IP 1.1.1.1.80 > 10.0.2.15.38670: Flags [.], seq 488132002, ack 3064539291, win 64240, length 0
         12:20:31.468543 docker0 curl.405939 Out IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132002, ack 3064539291, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.468562 veth1d387b0 curl.405939 Out IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132002, ack 3064539291, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.468668 eth0 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132002, ack 3064539291, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.468668 eth0@4026533097 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132002, ack 3064539291, win 64240, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.575358 ens33 In IP 1.1.1.1.80 > 10.0.2.15.38670: Flags [P.], seq 488132002:488132388, ack 3064539291, win 64240, length 386
         12:20:31.575586 docker0 curl.405939 Out IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [P.], seq 488132002:488132388, ack 3064539291, win 64240, length 386, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.575617 veth1d387b0 curl.405939 Out IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [P.], seq 488132002:488132388, ack 3064539291, win 64240, length 386, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.575732 eth0 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [P.], seq 488132002:488132388, ack 3064539291, win 64240, length 386, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.575855 eth0 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539291, ack 488132388, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.575732 eth0@4026533097 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [P.], seq 488132002:488132388, ack 3064539291, win 64240, length 386, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.575855 eth0@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539291, ack 488132388, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.575870 veth1d387b0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539291, ack 488132388, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.575883 docker0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539291, ack 488132388, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.575920 ens33 Out IP 10.0.2.15.38670 > 1.1.1.1.80: Flags [.], seq 3064539291, ack 488132388, win 63854, length 0
-        12:20:31.577059 eth0 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [F.], seq 3064539291, ack 488132388, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.577059 eth0@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [F.], seq 3064539291, ack 488132388, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.577074 veth1d387b0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [F.], seq 3064539291, ack 488132388, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.577082 docker0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [F.], seq 3064539291, ack 488132388, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.577148 ens33 Out IP 10.0.2.15.38670 > 1.1.1.1.80: Flags [F.], seq 3064539291, ack 488132388, win 63854, length 0
         12:20:31.577704 ens33 In IP 1.1.1.1.80 > 10.0.2.15.38670: Flags [.], seq 488132388, ack 3064539292, win 64239, length 0
         12:20:31.577764 docker0 curl.405939 Out IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132388, ack 3064539292, win 64239, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.577774 veth1d387b0 curl.405939 Out IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132388, ack 3064539292, win 64239, length 0, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.577835 eth0 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132388, ack 3064539292, win 64239, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.577835 eth0@4026533097 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [.], seq 488132388, ack 3064539292, win 64239, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.686955 ens33 In IP 1.1.1.1.80 > 10.0.2.15.38670: Flags [FP.], seq 488132388, ack 3064539292, win 64239, length 0
         12:20:31.687183 docker0 curl.405939 Out IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [FP.], seq 488132388, ack 3064539292, win 64239, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.687218 veth1d387b0 curl.405939 Out IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [FP.], seq 488132388, ack 3064539292, win 64239, length 0, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.687316 eth0 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [FP.], seq 488132388, ack 3064539292, win 64239, length 0, ParentProc [bash.405653], Container [musing_banach]
-        12:20:31.687369 eth0 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539292, ack 488132389, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.687316 eth0@4026533097 curl.405939 In IP 1.1.1.1.80 > 172.17.0.4.38670: Flags [FP.], seq 488132388, ack 3064539292, win 64239, length 0, ParentProc [bash.405653], Container [musing_banach]
+        12:20:31.687369 eth0@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539292, ack 488132389, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.687388 veth1d387b0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539292, ack 488132389, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.687404 docker0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [.], seq 3064539292, ack 488132389, win 63854, length 0, ParentProc [bash.405653], Container [musing_banach]
         12:20:31.687457 ens33 Out IP 10.0.2.15.38670 > 1.1.1.1.80: Flags [.], seq 3064539292, ack 488132389, win 63854, length 0

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -122,7 +122,7 @@ func headerTips(opts *Options) {
 
 	msg := fmt.Sprintf("capturing on %s, link-type EN10MB (Ethernet), snapshot length %d bytes, backend %s"+
 		", current network namespace %d",
-		interfaces, opts.snapshotLength, opts.backend, types.SelfNs.Inode())
+		interfaces, opts.snapshotLength, opts.backend, types.GetSelfNs().Inode())
 
 	if opts.verbose < 1 {
 		log.Warn("ptcpdump: verbose output suppressed, use -v[v]... for verbose output")

--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mozillazg/ptcpdump/internal/consumer"
 	"github.com/mozillazg/ptcpdump/internal/log"
 	"github.com/mozillazg/ptcpdump/internal/metadata"
+	"github.com/mozillazg/ptcpdump/internal/types"
 	"github.com/mozillazg/ptcpdump/internal/utils"
 	"os"
 	"os/signal"
@@ -119,8 +120,9 @@ func headerTips(opts *Options) {
 		interfaces = fmt.Sprintf("[%s]", strings.Join(opts.ifaces, ", "))
 	}
 
-	msg := fmt.Sprintf("capturing on %s, link-type EN10MB (Ethernet), snapshot length %d bytes, backend %s",
-		interfaces, opts.snapshotLength, opts.backend)
+	msg := fmt.Sprintf("capturing on %s, link-type EN10MB (Ethernet), snapshot length %d bytes, backend %s"+
+		", current network namespace %d",
+		interfaces, opts.snapshotLength, opts.backend, types.SelfNs.Inode())
 
 	if opts.verbose < 1 {
 		log.Warn("ptcpdump: verbose output suppressed, use -v[v]... for verbose output")

--- a/internal/event/net.go
+++ b/internal/event/net.go
@@ -67,7 +67,11 @@ func ParsePacketEvent(deviceCache *metadata.DeviceCache, event bpf.BpfPacketEven
 	ifindex := event.Meta.Ifindex
 	ifName := utils.GoStringUint(event.Meta.Ifname[:])
 	isFromSkb := len(ifName) > 0
-	p.Device, _ = deviceCache.GetByIfindex(int(ifindex), uint32(p.NetNs))
+	var ok bool
+	p.Device, ok = deviceCache.GetByKnownIfindex(int(ifindex))
+	if !ok {
+		p.Device, _ = deviceCache.GetByIfindex(int(ifindex), uint32(p.NetNs))
+	}
 	if p.Device.IsDummy() {
 		netns := event.Meta.NetnsId
 		if len(ifName) > 0 {

--- a/internal/metadata/device.go
+++ b/internal/metadata/device.go
@@ -129,8 +129,11 @@ func (d *DeviceCache) GetByIfindex(ifindex int, netNsInode uint32) (types.Device
 			}
 		}
 	}
-	for _, links := range d.allLinks {
+	for inode, links := range d.allLinks {
 		for _, dev := range links {
+			if inode > 0 && inode == types.SelfNs.Inode() {
+				ns = types.SelfNs
+			}
 			if dev.Index == ifindex {
 				return types.Device{
 					Name:    dev.Name,

--- a/internal/metadata/netns.go
+++ b/internal/metadata/netns.go
@@ -99,8 +99,8 @@ func (n *NetNsCache) GetOrFetchByPath(p string) (*types.NetNs, error) {
 func (n *NetNsCache) GetCurrentNs() *types.NetNs {
 	p := "/proc/self/ns/net"
 	ns, _ := n.GetOrFetchByPath(p)
-	if ns != nil && types.SelfNs == nil {
-		types.SelfNs = ns
+	if ns != nil && types.GetSelfNs() == nil {
+		types.SetSelfNs(ns)
 		log.Infof("set self netns: %d with path: %s", ns.Inode(), p)
 	}
 	return ns

--- a/internal/metadata/netns.go
+++ b/internal/metadata/netns.go
@@ -99,6 +99,10 @@ func (n *NetNsCache) GetOrFetchByPath(p string) (*types.NetNs, error) {
 func (n *NetNsCache) GetCurrentNs() *types.NetNs {
 	p := "/proc/self/ns/net"
 	ns, _ := n.GetOrFetchByPath(p)
+	if ns != nil && types.SelfNs == nil {
+		types.SelfNs = ns
+		log.Infof("set self netns: %d with path: %s", ns.Inode(), p)
+	}
 	return ns
 }
 

--- a/internal/types/device.go
+++ b/internal/types/device.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 type Device struct {
@@ -64,6 +65,10 @@ func NewDummyDevice(ifindex int, ns *NetNs) Device {
 
 func (d *Device) IsDummy() bool {
 	return d.Name == fmt.Sprintf("dummy-%d", d.Ifindex)
+}
+
+func (d *Device) HasDummyName() bool {
+	return d.IsDummy() && strings.HasPrefix(d.Name, "dummy-")
 }
 
 func (d *Device) Key() string {

--- a/internal/types/netns.go
+++ b/internal/types/netns.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 )
 
-var SelfNs *NetNs
+var selfNs *NetNs
 
 type NetNs struct {
 	handle netns.NsHandle
@@ -18,10 +18,18 @@ type NetNs struct {
 
 func init() {
 	var err error
-	SelfNs, err = NewNetNs("/proc/self/ns/net")
+	selfNs, err = NewNetNs("/proc/self/ns/net")
 	if err != nil {
 		fmt.Printf("error creating self netns: %v", err)
 	}
+}
+
+func GetSelfNs() *NetNs {
+	return selfNs
+}
+
+func SetSelfNs(ns *NetNs) {
+	selfNs = ns
 }
 
 func NewNetNs(netNsPath string) (*NetNs, error) {

--- a/internal/types/netns.go
+++ b/internal/types/netns.go
@@ -7,11 +7,21 @@ import (
 	"runtime"
 )
 
+var SelfNs *NetNs
+
 type NetNs struct {
 	handle netns.NsHandle
 	path   string
 
 	inode uint32
+}
+
+func init() {
+	var err error
+	SelfNs, err = NewNetNs("/proc/self/ns/net")
+	if err != nil {
+		fmt.Printf("error creating self netns: %v", err)
+	}
 }
 
 func NewNetNs(netNsPath string) (*NetNs, error) {

--- a/internal/writer/stdout.go
+++ b/internal/writer/stdout.go
@@ -56,6 +56,19 @@ func (w *StdoutWriter) Write(e *event.Packet) error {
 	}
 
 	ifName := e.Device.Name
+	netNs := e.Device.NetNs.Inode()
+	if netNs <= 0 || e.Device.IsDummy() {
+		netNs = uint32(e.NetNs)
+	}
+	log.Infof("ifindex %d types.SelfNs.Inode(): %d", e.Device.Ifindex, types.SelfNs.Inode())
+	if netNs > 0 && netNs != types.SelfNs.Inode() {
+		if e.Device.HasDummyName() {
+			ifName = fmt.Sprintf("%d@%d", e.Device.Ifindex, netNs)
+		} else {
+			ifName = fmt.Sprintf("%s@%d", ifName, netNs)
+		}
+	}
+
 	packetType := ""
 	if e.Egress() {
 		packetType = "Out"

--- a/internal/writer/stdout.go
+++ b/internal/writer/stdout.go
@@ -60,8 +60,8 @@ func (w *StdoutWriter) Write(e *event.Packet) error {
 	if netNs <= 0 || e.Device.IsDummy() {
 		netNs = uint32(e.NetNs)
 	}
-	log.Infof("ifindex %d types.SelfNs.Inode(): %d", e.Device.Ifindex, types.SelfNs.Inode())
-	if netNs > 0 && netNs != types.SelfNs.Inode() {
+	log.Infof("ifindex %d types.GetSelfNs().Inode(): %d", e.Device.Ifindex, types.GetSelfNs().Inode())
+	if netNs > 0 && netNs != types.GetSelfNs().Inode() {
 		if e.Device.HasDummyName() {
 			ifName = fmt.Sprintf("%d@%d", e.Device.Ifindex, netNs)
 		} else {


### PR DESCRIPTION
before:

```
12:20:31.336316 eth0 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, ParentProc [bash.405653], Container [musing_banach]Add commentMore actions
12:20:31.336382 veth1d387b0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, ParentProc [bash.405653], Container [musing_banach]
12:20:31.336443 docker0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, ParentProc [bash.405653], Container [musing_banach]
12:20:31.336801 ens33 Out IP 10.0.2.15.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0
```

after:

```
12:20:31.336316 eth0@4026533097 curl.405939 Out IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, ParentProc [bash.405653], Container [musing_banach]Add commentMore actions
12:20:31.336382 veth1d387b0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, ParentProc [bash.405653], Container [musing_banach]
12:20:31.336443 docker0 curl.405939 In IP 172.17.0.4.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0, ParentProc [bash.405653], Container [musing_banach]
12:20:31.336801 ens33 Out IP 10.0.2.15.38670 > 1.1.1.1.80: Flags [S], seq 3064539219, win 64240, options [mss 1460,sackOK,TS val 1731159046 ecr 0,nop,wscale 7], length 0
```