### PR TITLE
chore: enable PIE in dynamic builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ GO_LDFLAGS += -X github.com/mozillazg/ptcpdump/internal.Version=$(VERSION)
 GO_LDFLAGS += -X github.com/mozillazg/ptcpdump/internal.GitCommit=$(GIT_COMMIT)
 GO_LDFLAGS_DYNAMIC := -X github.com/mozillazg/ptcpdump/internal.Version=$(VERSION)
 GO_LDFLAGS_DYNAMIC += -X github.com/mozillazg/ptcpdump/internal.GitCommit=$(GIT_COMMIT)
+GO_LDFLAGS_DYNAMIC += -buildmode=pie
 COVERAGE_FLAG ?=
 COVERAGE_ARGS ?=
 


### PR DESCRIPTION
This change makes dynamic executables position-independent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build configuration updated so dynamically linked binaries are produced as position-independent executables (PIE), improving runtime hardening and compatibility with stricter platform security policies.
  * No functional behavior changes expected; existing flags and control flow remain unchanged.
  * Binary artifacts may differ at the build level, but packaging and deployment workflows are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->